### PR TITLE
feat: add XDG Base Directory support (#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "fix": "bun lint:fix && bun format",
     "start": "bun src/index.ts",
     "link:waha-node": "bash scripts/link-waha-node.sh",
-    "unlink:waha-node": "bash scripts/unlink-waha-node.sh"
+    "unlink:waha-node": "bash scripts/unlink-waha-node.sh",
+    "migration:create": "bun run scripts/create-migration.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/scripts/create-migration.ts
+++ b/scripts/create-migration.ts
@@ -1,0 +1,77 @@
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs"
+import { join } from "node:path"
+
+// Get migration name from args
+const args = process.argv.slice(2)
+if (args.length === 0) {
+  console.error("Please provide a migration name")
+  console.error("Usage: bun run migration:create <name>")
+  process.exit(1)
+}
+
+const name = args.join("_").toLowerCase()
+const timestamp = Math.floor(Date.now() / 1000).toString()
+const filename = `${timestamp}_${name}`
+
+// Ensure directory exists
+const migrationsDir = join(process.cwd(), "src", "utils", "migrations")
+if (!existsSync(migrationsDir)) {
+  mkdirSync(migrationsDir, { recursive: true })
+}
+
+// 1. Create migration file
+const filePath = join(migrationsDir, `${filename}.ts`)
+const template = `/**
+ * Migration: ${name.replace(/_/g, " ")}
+ */
+
+import { debugLog } from "../debug"
+
+export const name = "${name}"
+
+export function up(): boolean {
+  debugLog("Migrations", "Running migration: ${name}")
+  // TODO: Implement migration logic
+  return true
+}
+
+export function down(): boolean {
+  debugLog("Migrations", "Reverting migration: ${name}")
+  // TODO: Implement revert logic
+  return true
+}
+`
+
+writeFileSync(filePath, template)
+console.log(`Created migration: src/utils/migrations/${filename}.ts`)
+
+// 2. Register in src/utils/migrations.ts
+const registryPath = join(process.cwd(), "src", "utils", "migrations.ts")
+if (existsSync(registryPath)) {
+  let content = readFileSync(registryPath, "utf-8")
+
+  // Create the registration code block
+  const registrationCode = `
+  try {
+    const m${timestamp} = await import("./migrations/${filename}")
+    migrations.push({
+      timestamp: "${timestamp}",
+      name: m${timestamp}.name,
+      up: m${timestamp}.up,
+      down: m${timestamp}.down,
+    })
+  } catch (e) {
+    debugLog("Migrations", \`Failed to load migration: \${e}\`)
+  }
+`
+
+  // Insert before the "Add future migrations here" comment
+  const keyComment = "// Add future migrations here:"
+  if (content.includes(keyComment)) {
+    content = content.replace(keyComment, `${registrationCode}\n  ${keyComment}`)
+    writeFileSync(registryPath, content)
+    console.log(`Registered in src/utils/migrations.ts`)
+  } else {
+    console.warn("Could not find registration point in src/utils/migrations.ts")
+  }
+}

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -16,12 +16,13 @@ import { DEFAULT_ENV, DEFAULT_CONFIG_META } from "./schema"
 import { debugLog } from "../utils/debug"
 import { VersionInfo } from "./version"
 
-const CONFIG_DIR_NAME = ".waha-tui"
+const CONFIG_DIR_NAME = "waha-tui"
 const ENV_FILE_NAME = ".env"
 const CONFIG_FILE_NAME = "config.json"
 
 export function getConfigDir(): string {
-  return join(homedir(), CONFIG_DIR_NAME)
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
+  return join(xdgConfigHome, CONFIG_DIR_NAME)
 }
 
 export function getEnvPath(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,10 @@ async function main() {
   initDebug()
   debugLog("App", "WAHA TUI starting...")
 
+  // Run migrations (e.g., move config from ~/.waha-tui to XDG location)
+  const { runMigrations } = await import("./utils/migrations")
+  await runMigrations()
+
   // Create renderer FIRST so we can use it for everything including config
   const renderer = await createCliRenderer({ exitOnCtrlC: true })
 

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -16,8 +16,14 @@ const hasEnvDebug = process.env.WAHA_TUI_DEBUG === "1" || process.env.WAHA_TUI_D
 
 export const DEBUG_ENABLED = hasDebugFlag || hasEnvDebug
 
-// Save debug log to ~/.waha-tui/ like other config files
-const wahaTuiDir = join(homedir(), ".waha-tui")
+// Compute XDG path locally to avoid circular dependency with manager.ts
+function getXdgConfigDir(): string {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
+  return join(xdgConfigHome, "waha-tui")
+}
+
+// Save debug log to XDG config dir like other config files
+const wahaTuiDir = getXdgConfigDir()
 const logFile = join(wahaTuiDir, "debug.log")
 
 /**

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,0 +1,128 @@
+/**
+ * Migration Runner
+ * Sequelize-style migrations with Unix timestamp naming
+ *
+ * Migration files: src/utils/migrations/{timestamp}_{name}.ts
+ * Each migration exports: name, up()
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { homedir } from "node:os"
+import { debugLog } from "./debug"
+
+/**
+ * Get the XDG config directory for waha-tui
+ */
+function getXdgConfigDir(): string {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
+  return join(xdgConfigHome, "waha-tui")
+}
+
+const WAHA_TUI_DIR = getXdgConfigDir()
+const MIGRATIONS_FILE = join(WAHA_TUI_DIR, ".migrations.json")
+
+interface MigrationState {
+  applied: string[] // List of applied migration timestamps
+  lastRun: string
+}
+
+interface Migration {
+  timestamp: string
+  name: string
+  up: () => boolean | Promise<boolean>
+  down: () => boolean | Promise<boolean>
+}
+
+/**
+ * Ensure the waha-tui directory exists
+ */
+function ensureWahaTuiDir(): void {
+  if (!existsSync(WAHA_TUI_DIR)) {
+    mkdirSync(WAHA_TUI_DIR, { recursive: true })
+  }
+}
+
+/**
+ * Get the current migration state
+ */
+function getMigrationState(): MigrationState {
+  if (!existsSync(MIGRATIONS_FILE)) {
+    return { applied: [], lastRun: "" }
+  }
+
+  try {
+    const content = readFileSync(MIGRATIONS_FILE, "utf-8")
+    return JSON.parse(content) as MigrationState
+  } catch {
+    return { applied: [], lastRun: "" }
+  }
+}
+
+/**
+ * Save the migration state
+ */
+function saveMigrationState(state: MigrationState): void {
+  ensureWahaTuiDir()
+  state.lastRun = new Date().toISOString()
+  writeFileSync(MIGRATIONS_FILE, JSON.stringify(state, null, 2), "utf-8")
+}
+
+/**
+ * Load all migration modules
+ */
+async function loadMigrations(): Promise<Migration[]> {
+  const migrations: Migration[] = []
+
+  // Import migrations directly - bundled at build time
+  try {
+    const m1766511205 = await import("./migrations/1766511205_migrate_to_xdg")
+    migrations.push({
+      timestamp: "1766511205",
+      name: m1766511205.name,
+      up: m1766511205.up,
+      down: m1766511205.down,
+    })
+  } catch (e) {
+    debugLog("Migrations", `Failed to load migration: ${e}`)
+  }
+
+  // Add future migrations here:
+  // const m2 = await import("./migrations/1734xxxxxx_xxx")
+  // migrations.push({ timestamp: "...", name: m2.name, up: m2.up })
+
+  return migrations.sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+}
+
+/**
+ * Run all pending migrations
+ */
+export async function runMigrations(): Promise<void> {
+  const state = getMigrationState()
+  const migrations = await loadMigrations()
+
+  let hasChanges = false
+
+  for (const migration of migrations) {
+    if (state.applied.includes(migration.timestamp)) {
+      continue
+    }
+
+    debugLog("Migrations", `Running migration ${migration.timestamp}_${migration.name}`)
+
+    try {
+      await migration.up()
+      state.applied.push(migration.timestamp)
+      hasChanges = true
+      debugLog("Migrations", `Migration ${migration.timestamp} completed`)
+    } catch (e) {
+      debugLog("Migrations", `Migration ${migration.timestamp} failed: ${e}`)
+    }
+  }
+
+  if (hasChanges) {
+    saveMigrationState(state)
+  } else {
+    debugLog("Migrations", "No pending migrations")
+  }
+}

--- a/src/utils/migrations/1766511205_migrate_to_xdg.ts
+++ b/src/utils/migrations/1766511205_migrate_to_xdg.ts
@@ -1,0 +1,102 @@
+/**
+ * Migration: migrate to xdg
+ *
+ * Moves config from ~/.waha-tui to $XDG_CONFIG_HOME/waha-tui
+ */
+
+import { existsSync, lstatSync } from "node:fs"
+import { readdir, mkdir, copyFile, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { homedir } from "node:os"
+import { debugLog } from "../debug"
+
+export const name = "migrate_to_xdg"
+
+const OLD_DIR = join(homedir(), ".waha-tui")
+
+function getNewDir(): string {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
+  return join(xdgConfigHome, "waha-tui")
+}
+
+export async function up(): Promise<boolean> {
+  const newDir = getNewDir()
+
+  // Skip if old directory doesn't exist
+  if (!existsSync(OLD_DIR)) {
+    debugLog("Migrations", "No legacy ~/.waha-tui directory found, skipping migration")
+    return false
+  }
+
+  // Skip if already at XDG location (same path)
+  if (OLD_DIR === newDir) {
+    debugLog("Migrations", "Old and new paths are identical, skipping")
+    return false
+  }
+
+  // Skip if new directory already has config
+  if (existsSync(join(newDir, "config.json"))) {
+    debugLog("Migrations", "XDG config already exists, skipping migration")
+    return false
+  }
+
+  debugLog("Migrations", `Migrating from ${OLD_DIR} to ${newDir}`)
+
+  try {
+    // Ensure target directory exists
+    if (!existsSync(newDir)) {
+      await mkdir(newDir, { recursive: true })
+      debugLog("Migrations", `Created directory ${newDir}`)
+    }
+
+    // Get all files in old directory
+    const entries = await readdir(OLD_DIR)
+
+    // Filter to only include regular files (skip directories, symlinks, etc.)
+    const files = entries.filter((entry) => {
+      const entryPath = join(OLD_DIR, entry)
+      try {
+        const stat = lstatSync(entryPath)
+        return stat.isFile()
+      } catch {
+        return false
+      }
+    })
+
+    for (const file of files) {
+      const oldPath = join(OLD_DIR, file)
+      const newPath = join(newDir, file)
+
+      // Skip if file already exists in new location
+      if (existsSync(newPath)) {
+        debugLog("Migrations", `Skipping ${file}, already exists in new location`)
+        continue
+      }
+
+      // Copy file to new location
+      await copyFile(oldPath, newPath)
+      debugLog("Migrations", `Copied ${file} to XDG location`)
+    }
+
+    // Remove old directory completely (including any subdirectories)
+    try {
+      await rm(OLD_DIR, { recursive: true, force: true })
+      debugLog("Migrations", `Removed legacy directory ${OLD_DIR}`)
+    } catch {
+      debugLog("Migrations", `Could not remove old directory`)
+    }
+
+    debugLog("Migrations", "XDG migration completed successfully")
+    return true
+  } catch (e) {
+    debugLog("Migrations", `Migration error: ${e}`)
+    return false
+  }
+}
+
+export function down(): boolean {
+  // This migration is not easily reversible
+  // The old config location is deprecated
+  debugLog("Migrations", "XDG migration rollback not supported")
+  return false
+}


### PR DESCRIPTION
- Move config from ~/.waha-tui to $XDG_CONFIG_HOME/waha-tui
- Add migration framework for automatic config updates
- Add migration script: bun run migration:create <name>
- Migrate existing users' configs on first run

Config now follows the XDG spec, defaulting to ~/.config/waha-tui

Fixes #12