### PR TITLE
feat: add phone number pairing as alternative auth method (#13)

### DIFF
--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -14,6 +14,7 @@ import type {
 import { debugLog } from "../utils/debug"
 import { getChatIdString, normalizeId } from "../utils/formatters"
 import type { WAMessageExtended } from "../types"
+import type { QRCode } from "qrcode"
 
 // Context menu types
 export type ContextMenuType = "chat" | "message" | null
@@ -42,6 +43,8 @@ export type ViewType =
   | "loading"
 
 export type ActiveFilter = "all" | "unread" | "favorites" | "groups"
+export type AuthMode = "qr" | "phone"
+export type PairingStatus = "idle" | "requesting" | "success" | "error"
 export type ActiveIcon = "chats" | "status" | "profile" | "settings" | "channels" | "communities"
 
 // Type of state change - enables render optimization
@@ -62,8 +65,13 @@ export interface AppState {
   currentChatId: string | null
   sessions: SessionDTO[]
   chats: ChatSummary[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  qrCodeMatrix: any | null // QRCode type from qrcode library
+  qrCodeMatrix: QRCode | null // QRCode type from qrcode library
+  // Phone pairing state
+  authMode: AuthMode
+  phoneNumber: string
+  pairingCode: string | null
+  pairingStatus: PairingStatus
+  pairingError: string | null
   messages: Map<string, WAMessageExtended[]>
   contactsCache: Map<string, string> // Maps contact ID to name
   allContacts: Map<string, string> // Full phonebook contacts for search
@@ -117,6 +125,12 @@ class StateManager {
     sessions: [],
     chats: [],
     qrCodeMatrix: null,
+    // Phone pairing state
+    authMode: "qr",
+    phoneNumber: "",
+    pairingCode: null,
+    pairingStatus: "idle",
+    pairingError: null,
     messages: new Map(),
     contactsCache: new Map(),
     allContacts: new Map(),

--- a/src/utils/pairing.ts
+++ b/src/utils/pairing.ts
@@ -1,0 +1,90 @@
+/**
+ * Phone Number Pairing utilities
+ * Alternative authentication method using pairing codes
+ */
+
+import { getClient } from "../client"
+import { debugLog } from "./debug"
+
+export interface PairingResult {
+  success: boolean
+  code?: string
+  error?: string
+}
+
+/**
+ * Request a pairing code for phone number authentication
+ * This is an alternative to QR code scanning
+ *
+ * @param sessionName - The session to authenticate
+ * @param phoneNumber - Phone number in international format (e.g., "12132132130")
+ * @returns PairingResult with code on success or error message on failure
+ */
+export async function requestPairingCode(
+  sessionName: string,
+  phoneNumber: string
+): Promise<PairingResult> {
+  try {
+    // Strip non-digits from phone number
+    const cleanNumber = phoneNumber.replace(/[^0-9]/g, "")
+
+    if (!cleanNumber || cleanNumber.length < 10) {
+      return {
+        success: false,
+        error: "Invalid phone number. Use international format without + (e.g., 12132132130)",
+      }
+    }
+
+    debugLog("Pairing", `Requesting code for: ${cleanNumber}`)
+    const client = getClient()
+
+    const { data } = await client.auth.authControllerRequestCode(sessionName, {
+      phoneNumber: cleanNumber,
+      method: undefined, // undefined = web pairing (not SMS/voice)
+    })
+
+    // The response should include a code property
+    const responseData = data as { code?: string } | undefined
+
+    if (responseData?.code) {
+      debugLog("Pairing", `Code received: ${responseData.code}`)
+      return { success: true, code: responseData.code }
+    }
+
+    return { success: false, error: "No pairing code returned from server" }
+  } catch (error: unknown) {
+    const axiosError = error as {
+      response?: {
+        data?: { message?: string; error?: string; statusCode?: number } | string
+        status?: number
+      }
+      message?: string
+    }
+
+    // Try to extract detailed error message
+    let msg = "Unknown error"
+    if (axiosError?.response?.data) {
+      const data = axiosError.response.data
+      if (typeof data === "string") {
+        msg = data
+      } else if (data.message) {
+        msg = data.message
+      } else if (data.error) {
+        msg = data.error
+      }
+    } else if (axiosError?.message) {
+      msg = axiosError.message
+    }
+
+    // Add status code context
+    const status = axiosError?.response?.status
+    if (status === 500) {
+      msg = `Server error: ${msg}. Make sure the session is showing QR code.`
+    } else if (status === 422) {
+      msg = `Invalid request: ${msg}`
+    }
+
+    debugLog("Pairing", `Request failed: ${msg}`)
+    return { success: false, error: msg }
+  }
+}

--- a/src/views/QRCodeView.ts
+++ b/src/views/QRCodeView.ts
@@ -1,11 +1,12 @@
 /**
- * QR Code Login View
- * WhatsApp Web-style login page with QR code and instructions
+ * Authentication View
+ * WhatsApp Web-style login page with QR code and phone number pairing option
  */
 
 import { Box, Text, TextAttributes } from "@opentui/core"
 import { appState } from "../state/AppState"
 import { getQRCode } from "../utils/qr"
+import { requestPairingCode } from "../utils/pairing"
 import { WhatsAppTheme, Icons } from "../config/theme"
 import QRCode from "qrcode"
 import type { QRCode as QRCodeType } from "qrcode"
@@ -17,6 +18,9 @@ import { createNewSession } from "./SessionCreate"
 // Module-level intervals for QR refresh and status checking
 let qrRefreshInterval: NodeJS.Timeout | null = null
 let statusCheckInterval: NodeJS.Timeout | null = null
+
+// Current session name for pairing requests
+let currentSessionName: string = ""
 
 /**
  * Stop QR code auto-refresh and status checking
@@ -33,58 +37,483 @@ export function stopQRRefresh(): void {
 }
 
 /**
- * QR Code Login View Component
- * Shows WhatsApp Web-style login page with instructions and QR code
+ * Toggle between QR and phone authentication modes
  */
-export function QRCodeView() {
+export function toggleAuthMode(): void {
+  const state = appState.getState()
+  const newMode = state.authMode === "qr" ? "phone" : "qr"
+  appState.setState({
+    authMode: newMode,
+    pairingCode: null,
+    pairingStatus: "idle",
+    pairingError: null,
+  })
+  debugLog("Auth", `Switched to ${newMode} mode`)
+}
+
+/**
+ * Handle phone number input character
+ */
+export function handlePhoneInput(char: string): void {
+  const state = appState.getState()
+  if (state.authMode !== "phone") return
+
+  // Only allow digits
+  if (/^\d$/.test(char)) {
+    appState.setState({
+      phoneNumber: state.phoneNumber + char,
+      pairingError: null,
+    })
+  }
+}
+
+/**
+ * Handle backspace in phone number input
+ */
+export function handlePhoneBackspace(): void {
+  const state = appState.getState()
+  if (state.authMode !== "phone") return
+
+  if (state.phoneNumber.length > 0) {
+    appState.setState({
+      phoneNumber: state.phoneNumber.slice(0, -1),
+      pairingError: null,
+    })
+  }
+}
+
+/**
+ * Submit phone number and request pairing code
+ */
+export async function submitPhoneNumber(): Promise<void> {
+  const state = appState.getState()
+  if (state.authMode !== "phone") return
+  if (state.pairingStatus === "requesting") return
+
+  const phoneNumber = state.phoneNumber.trim()
+  if (!phoneNumber || phoneNumber.length < 10) {
+    appState.setState({
+      pairingError: "Enter a valid phone number (10+ digits)",
+      pairingStatus: "error",
+    })
+    return
+  }
+
+  appState.setState({ pairingStatus: "requesting", pairingError: null })
+
+  const result = await requestPairingCode(currentSessionName, phoneNumber)
+
+  if (result.success && result.code) {
+    appState.setState({
+      pairingCode: result.code,
+      pairingStatus: "success",
+      pairingError: null,
+    })
+  } else {
+    appState.setState({
+      pairingStatus: "error",
+      pairingError: result.error || "Failed to get pairing code",
+    })
+  }
+}
+
+/**
+ * Build QR code lines from matrix
+ */
+function buildQRLines(qrMatrix: QRCodeType): string[] {
+  const qrLines: string[] = []
+  const BLOCK_FULL = "█"
+  const BLOCK_UPPER = "▀"
+  const BLOCK_LOWER = "▄"
+  const BLOCK_EMPTY = " "
+
+  const padding = 4
+  const modules = qrMatrix.modules
+
+  // Top padding
+  for (let i = 0; i < padding / 2; i++) {
+    qrLines.push(BLOCK_FULL.repeat(modules.size + padding * 2))
+  }
+
+  // Render QR using half-blocks (2 rows per line)
+  for (let y = 0; y < modules.size; y += 2) {
+    let line = BLOCK_FULL.repeat(padding)
+
+    for (let x = 0; x < modules.size; x++) {
+      const upperPixel = modules.data[y * modules.size + x] === 1
+      const lowerPixel =
+        y + 1 < modules.size ? modules.data[(y + 1) * modules.size + x] === 1 : false
+
+      if (upperPixel && lowerPixel) {
+        line += BLOCK_FULL
+      } else if (upperPixel && !lowerPixel) {
+        line += BLOCK_UPPER
+      } else if (!upperPixel && lowerPixel) {
+        line += BLOCK_LOWER
+      } else {
+        line += BLOCK_EMPTY
+      }
+    }
+
+    line += BLOCK_FULL.repeat(padding)
+    qrLines.push(line)
+  }
+
+  // Bottom padding
+  for (let i = 0; i < padding / 2; i++) {
+    qrLines.push(BLOCK_FULL.repeat(modules.size + padding * 2))
+  }
+
+  return qrLines
+}
+
+/**
+ * QR Mode Instructions Component
+ */
+function QRModeInstructions() {
+  return Box(
+    {
+      flexDirection: "column",
+      justifyContent: "center",
+      width: "40%",
+      paddingRight: 4,
+    },
+    Text({
+      content: "Steps to log in",
+      fg: WhatsAppTheme.textPrimary,
+      attributes: TextAttributes.BOLD,
+    }),
+    Box({ height: 1 }),
+    Box(
+      { flexDirection: "row" },
+      Text({ content: `${Icons.circled1} `, fg: WhatsAppTheme.textSecondary }),
+      Text({
+        content: `Open WhatsApp ${Icons.whatsapp} on your phone`,
+        fg: WhatsAppTheme.textPrimary,
+      })
+    ),
+    Box({ height: 1 }),
+    Box(
+      { flexDirection: "row" },
+      Text({ content: `${Icons.circled2} `, fg: WhatsAppTheme.textSecondary }),
+      Text({
+        content: "On Android tap Menu ⋮ · On iPhone tap Settings ⚙",
+        fg: WhatsAppTheme.textPrimary,
+      })
+    ),
+    Box({ height: 1 }),
+    Box(
+      { flexDirection: "row" },
+      Text({ content: `${Icons.circled3} `, fg: WhatsAppTheme.textSecondary }),
+      Text({ content: "Tap Linked devices, then Link device", fg: WhatsAppTheme.textPrimary })
+    ),
+    Box({ height: 1 }),
+    Box(
+      { flexDirection: "row" },
+      Text({ content: `${Icons.circled4} `, fg: WhatsAppTheme.textSecondary }),
+      Text({ content: "Scan the QR code to confirm", fg: WhatsAppTheme.textPrimary })
+    )
+  )
+}
+
+/**
+ * Phone Mode Input Component - WhatsApp Web style
+ * Single centered column with phone input and back link
+ */
+function PhoneModeInstructions() {
+  const state = appState.getState()
+
+  return Box(
+    {
+      flexDirection: "column",
+      alignItems: "center",
+    },
+    // Title
+    Text({
+      content: "Enter phone number",
+      fg: WhatsAppTheme.textPrimary,
+      attributes: TextAttributes.BOLD,
+    }),
+    // Subtitle
+    Text({
+      content: "Enter your phone number with country code",
+      fg: WhatsAppTheme.textSecondary,
+    }),
+    Box({ height: 2 }),
+    // Phone number input field
+    Box(
+      {
+        flexDirection: "row",
+        borderStyle: "rounded",
+        borderColor: WhatsAppTheme.borderLight,
+        paddingLeft: 2,
+        paddingRight: 2,
+        width: 30,
+      },
+      Text({
+        content: `+${state.phoneNumber || ""}█`,
+        fg: WhatsAppTheme.textPrimary,
+      })
+    ),
+    Box({ height: 2 }),
+    // Submit instruction (like "Next" button)
+    Box(
+      {
+        backgroundColor: WhatsAppTheme.green,
+        paddingLeft: 3,
+        paddingRight: 3,
+      },
+      Text({
+        content: "Press Enter",
+        fg: WhatsAppTheme.white,
+        attributes: TextAttributes.BOLD,
+      })
+    ),
+    Box({ height: 2 }),
+    // Back link
+    Text({
+      content: "Log in with QR code >",
+      fg: WhatsAppTheme.green,
+      attributes: TextAttributes.UNDERLINE,
+    }),
+    Text({
+      content: "(Press Q to switch)",
+      fg: WhatsAppTheme.textTertiary,
+    }),
+
+    // Error message
+    ...(state.pairingError
+      ? [
+          Box({ height: 1 }),
+          Text({
+            content: state.pairingError,
+            fg: "#ff6b6b",
+          }),
+        ]
+      : [])
+  )
+}
+
+/**
+ * QR Code Display with phone number link below
+ */
+function QRCodeDisplay() {
   const state = appState.getState()
   const qrMatrix = state.qrCodeMatrix
 
-  // Build QR code lines if we have a matrix
-  const qrLines: string[] = []
-  if (qrMatrix) {
-    const BLOCK_FULL = "█"
-    const BLOCK_UPPER = "▀"
-    const BLOCK_LOWER = "▄"
-    const BLOCK_EMPTY = " "
-
-    const padding = 4 // Extra vertical padding since half-blocks compress height by 2x
-    const modules = qrMatrix.modules
-
-    // Top padding
-    for (let i = 0; i < padding / 2; i++) {
-      qrLines.push(BLOCK_FULL.repeat(modules.size + padding * 2))
-    }
-
-    // Render QR using half-blocks (2 rows per line)
-    for (let y = 0; y < modules.size; y += 2) {
-      let line = BLOCK_FULL.repeat(padding)
-
-      for (let x = 0; x < modules.size; x++) {
-        const upperPixel = modules.data[y * modules.size + x] === 1
-        const lowerPixel =
-          y + 1 < modules.size ? modules.data[(y + 1) * modules.size + x] === 1 : false
-
-        if (upperPixel && lowerPixel) {
-          line += BLOCK_FULL
-        } else if (upperPixel && !lowerPixel) {
-          line += BLOCK_UPPER
-        } else if (!upperPixel && lowerPixel) {
-          line += BLOCK_LOWER
-        } else {
-          line += BLOCK_EMPTY
-        }
-      }
-
-      line += BLOCK_FULL.repeat(padding)
-      qrLines.push(line)
-    }
-
-    // Bottom padding
-    for (let i = 0; i < padding / 2; i++) {
-      qrLines.push(BLOCK_FULL.repeat(modules.size + padding * 2))
-    }
+  if (!qrMatrix) {
+    return Box(
+      {
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+      },
+      Text({
+        content: "Loading QR code...",
+        fg: WhatsAppTheme.textSecondary,
+      })
+    )
   }
+
+  const qrLines = buildQRLines(qrMatrix)
+
+  return Box(
+    {
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    // QR Code
+    ...qrLines.map((line) =>
+      Text({
+        content: line,
+        fg: WhatsAppTheme.green,
+      })
+    ),
+    // Spacing
+    Box({ height: 1 }),
+    // "Log in with phone number" link - like WhatsApp Web
+    Text({
+      content: "Log in with phone number >",
+      fg: WhatsAppTheme.green,
+      attributes: TextAttributes.UNDERLINE,
+    }),
+    Text({
+      content: "(Press P to switch)",
+      fg: WhatsAppTheme.textTertiary,
+    })
+  )
+}
+
+/**
+ * Pairing Code Display Component - WhatsApp Web style
+ * Single column layout with code at top and instructions below
+ */
+function PairingCodeDisplay() {
+  const state = appState.getState()
+
+  if (state.pairingStatus === "requesting") {
+    return Box(
+      {
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 2,
+      },
+      Text({
+        content: "Requesting pairing code...",
+        fg: WhatsAppTheme.textSecondary,
+      })
+    )
+  }
+
+  if (state.pairingStatus === "success" && state.pairingCode) {
+    // Split code into characters for individual box display
+    const codeChars = state.pairingCode.split("")
+
+    return Box(
+      {
+        flexDirection: "column",
+        alignItems: "center",
+      },
+      // Title
+      Text({
+        content: "Enter code on phone",
+        fg: WhatsAppTheme.textPrimary,
+        attributes: TextAttributes.BOLD,
+      }),
+      // Subtitle with phone number
+      Text({
+        content: `Linking WhatsApp account +${state.phoneNumber}`,
+        fg: WhatsAppTheme.textSecondary,
+      }),
+      Box({ height: 2 }),
+      // Code display - each character in its own box
+      Box(
+        {
+          flexDirection: "row",
+          borderStyle: "rounded",
+          borderColor: WhatsAppTheme.borderLight,
+
+          padding: 1,
+          paddingLeft: 2,
+          paddingRight: 2,
+        },
+        Box(
+          { flexDirection: "row", gap: 1 },
+          ...codeChars.map((char) =>
+            char === "-"
+              ? Box(
+                  {
+                    borderColor: WhatsAppTheme.background,
+                    paddingLeft: 1,
+                    paddingRight: 1,
+                  },
+                  Text({ content: "-", fg: WhatsAppTheme.textSecondary })
+                )
+              : Box(
+                  {
+                    borderStyle: "rounded",
+                    borderColor: WhatsAppTheme.borderLight,
+                    paddingLeft: 1,
+                    paddingRight: 1,
+                  },
+                  Text({
+                    content: char,
+                    fg: WhatsAppTheme.textPrimary,
+                    attributes: TextAttributes.BOLD,
+                  })
+                )
+          )
+        )
+      ),
+      Box({ height: 2 }),
+      // Instructions - numbered steps
+      Box(
+        { flexDirection: "column", alignItems: "flex-start" },
+        Box(
+          { flexDirection: "row" },
+          Text({ content: `${Icons.circled1} `, fg: WhatsAppTheme.textSecondary }),
+          Text({
+            content: `Open WhatsApp ${Icons.whatsapp} on your phone`,
+            fg: WhatsAppTheme.textPrimary,
+          })
+        ),
+        Box({ height: 1 }),
+        Box(
+          { flexDirection: "row" },
+          Text({ content: `${Icons.circled2} `, fg: WhatsAppTheme.textSecondary }),
+          Text({
+            content: "On Android tap Menu ⋮ · On iPhone tap Settings ⚙",
+            fg: WhatsAppTheme.textPrimary,
+          })
+        ),
+        Box({ height: 1 }),
+        Box(
+          { flexDirection: "row" },
+          Text({ content: `${Icons.circled3} `, fg: WhatsAppTheme.textSecondary }),
+          Text({ content: "Tap Linked devices, then Link device", fg: WhatsAppTheme.textPrimary })
+        ),
+        Box({ height: 1 }),
+        Box(
+          { flexDirection: "row" },
+          Text({ content: `${Icons.circled4} `, fg: WhatsAppTheme.textSecondary }),
+          Text({
+            content: "Tap Link with phone number instead and enter this code",
+            fg: WhatsAppTheme.textPrimary,
+          })
+        )
+      ),
+      Box({ height: 2 }),
+      // Back link
+      Text({
+        content: "Log in with QR code >",
+        fg: WhatsAppTheme.green,
+        attributes: TextAttributes.UNDERLINE,
+      }),
+      Text({
+        content: "(Press Q to switch)",
+        fg: WhatsAppTheme.textTertiary,
+      })
+    )
+  }
+
+  // Default: waiting for input - show prompt to enter phone number
+  return Box(
+    {
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      padding: 2,
+    },
+    Text({
+      content: "Enter your phone number",
+      fg: WhatsAppTheme.textSecondary,
+    }),
+    Box({ height: 1 }),
+    Text({
+      content: "and press Enter",
+      fg: WhatsAppTheme.textSecondary,
+    }),
+    Box({ height: 2 }),
+    Text({
+      content: "< Back to QR code",
+      fg: WhatsAppTheme.green,
+      attributes: TextAttributes.UNDERLINE,
+    }),
+    Text({
+      content: "(Press Q to switch)",
+      fg: WhatsAppTheme.textTertiary,
+    })
+  )
+}
+
+/**
+ * Authentication View Component (QR Code or Phone Pairing)
+ */
+export function QRCodeView() {
+  const state = appState.getState()
+  const isPhoneMode = state.authMode === "phone"
 
   return Box(
     {
@@ -115,99 +544,32 @@ export function QRCodeView() {
         padding: 2,
       },
 
-      // Left side - Instructions
       Box(
         {
-          flexDirection: "column",
-          width: "40%",
+          flexDirection: isPhoneMode ? "column" : "row",
+          borderStyle: "rounded",
+          justifyContent: "center",
+          alignItems: "center",
+          borderColor: WhatsAppTheme.borderLight,
+          padding: 3,
+          paddingLeft: 4,
           paddingRight: 4,
         },
-        Text({
-          content: "Steps to log in",
-          fg: WhatsAppTheme.textPrimary,
-          attributes: TextAttributes.BOLD,
-        }),
-        Box({ height: 1 }),
-        // Step 1
-        Box(
-          { flexDirection: "row" },
-          Text({
-            content: `${Icons.circled1} `,
-            fg: WhatsAppTheme.textSecondary,
-          }),
-          Text({
-            content: `Open WhatsApp ${Icons.whatsapp} on your phone`,
-            fg: WhatsAppTheme.textPrimary,
-          })
-        ),
-        Box({ height: 1 }),
-        // Step 2
-        Box(
-          { flexDirection: "row" },
-          Text({
-            content: `${Icons.circled2} `,
-            fg: WhatsAppTheme.textSecondary,
-          }),
-          Text({
-            content: "On Android tap Menu ⋮ · On iPhone tap Settings ⚙",
-            fg: WhatsAppTheme.textPrimary,
-          })
-        ),
-        Box({ height: 1 }),
-        // Step 3
-        Box(
-          { flexDirection: "row" },
-          Text({
-            content: `${Icons.circled3} `,
-            fg: WhatsAppTheme.textSecondary,
-          }),
-          Text({
-            content: "Tap Linked devices, then Link device",
-            fg: WhatsAppTheme.textPrimary,
-          })
-        ),
-        Box({ height: 1 }),
-        // Step 4
-        Box(
-          { flexDirection: "row" },
-          Text({
-            content: `${Icons.circled4} `,
-            fg: WhatsAppTheme.textSecondary,
-          }),
-          Text({
-            content: "Scan the QR code to confirm",
-            fg: WhatsAppTheme.textPrimary,
-          })
-        )
-      ),
 
-      // Right side - QR Code
-      Box(
-        {
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-        },
-        ...(qrMatrix
-          ? qrLines.map((line) =>
-              Text({
-                content: line,
-                fg: WhatsAppTheme.green,
-              })
-            )
-          : [
-              Text({
-                content: "Loading QR code...",
-                fg: WhatsAppTheme.textSecondary,
-              }),
-            ])
+        ...(isPhoneMode
+          ? [
+              state.pairingStatus === "success" && state.pairingCode
+                ? PairingCodeDisplay()
+                : PhoneModeInstructions(),
+            ]
+          : [QRModeInstructions(), QRCodeDisplay()])
       )
     ),
 
     // Footer
     Box(
       {
-        height: 3,
+        height: 2,
         width: "100%",
         justifyContent: "center",
         alignItems: "center",
@@ -227,6 +589,18 @@ export function QRCodeView() {
 export async function showQRCode(name: string): Promise<void> {
   // Stop any existing refresh intervals
   stopQRRefresh()
+
+  // Store session name for pairing requests
+  currentSessionName = name
+
+  // Reset auth state
+  appState.setState({
+    authMode: "qr",
+    phoneNumber: "",
+    pairingCode: null,
+    pairingStatus: "idle",
+    pairingError: null,
+  })
 
   const client = getClient()
 
@@ -393,8 +767,9 @@ export async function showQRCode(name: string): Promise<void> {
 
   // Function to load/refresh QR code (called every 15s)
   const loadQR = async (isInitialLoad: boolean = false) => {
-    // Only refresh if still on QR view
-    if (appState.getState().currentView !== "qr") {
+    // Only refresh if still on QR view and in QR mode
+    const state = appState.getState()
+    if (state.currentView !== "qr" || state.authMode !== "qr") {
       return
     }
 


### PR DESCRIPTION
Implements phone number pairing to address QR code scanning issues. Users can now authenticate via pairing code instead of QR scan.

Changes:
- Add phone pairing state to AppState (authMode, phoneNumber, pairingCode, pairingStatus, pairingError)
- Create pairing.ts utility for requesting codes from WAHA API
- Redesign QRCodeView with WhatsApp Web-style layouts:
  - QR mode: two-panel layout with instructions + QR code
  - Phone input: centered single-column with bordered input field
  - Pairing code: individual character boxes with instructions
- Add keyboard controls: P (phone mode), Q (QR mode), digits, Enter, Escape

Fixes #14