### PR TITLE
Relocate contributing and security guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,17 +225,7 @@ waha-tui/
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## Security
-
-See [SECURITY.md](SECURITY.md) for security policy and reporting vulnerabilities.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 


### PR DESCRIPTION
Move contributing and security guidelines from the README to separate files for better organization and clarity. Add a link to the new security section in the README.