### PR TITLE
feat(error): add typed error classes and improve error handling

### DIFF
--- a/src/client/chatActions.test.ts
+++ b/src/client/chatActions.test.ts
@@ -5,6 +5,7 @@
 
 import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
 
+import { NetworkError } from "../services/Errors"
 import { errorService } from "../services/ErrorService"
 import { archiveChat, deleteChat, markChatUnread, unarchiveChat } from "./chatActions"
 import * as core from "./core"
@@ -38,28 +39,34 @@ describe("chatActions", () => {
 
   describe("archiveChat", () => {
     it("should archive a chat successfully", async () => {
-      const result = await archiveChat("123@c.us")
+      await archiveChat("123@c.us")
 
-      expect(result).toBe(true)
       expect(mockChatsController.chatsControllerArchiveChat).toHaveBeenCalledWith(
         "test-session",
         "123@c.us"
       )
     })
 
-    it("should return false on error", async () => {
+    it("should throw NetworkError on error", async () => {
       mockChatsController.chatsControllerArchiveChat.mockRejectedValueOnce(new Error("API Error"))
 
-      const result = await archiveChat("123@c.us")
-
-      expect(result).toBe(false)
+      await expect(() => archiveChat("123@c.us")).toThrow(NetworkError)
     })
 
     it("should call errorService.handle on error", async () => {
       const handleSpy = spyOn(errorService, "handle")
       mockChatsController.chatsControllerArchiveChat.mockRejectedValueOnce(new Error("API Error"))
 
-      await archiveChat("123@c.us")
+      await expect(() => archiveChat("123@c.us")).toThrow(NetworkError)
+
+      expect(handleSpy).toHaveBeenCalled()
+    })
+
+    it("should call errorService.handle on error", async () => {
+      const handleSpy = spyOn(errorService, "handle")
+      mockChatsController.chatsControllerArchiveChat.mockRejectedValueOnce(new Error("API Error"))
+
+      await expect(() => archiveChat("123@c.us")).toThrow(NetworkError)
 
       expect(handleSpy).toHaveBeenCalled()
     })
@@ -67,61 +74,52 @@ describe("chatActions", () => {
 
   describe("unarchiveChat", () => {
     it("should unarchive a chat successfully", async () => {
-      const result = await unarchiveChat("123@c.us")
+      await unarchiveChat("123@c.us")
 
-      expect(result).toBe(true)
       expect(mockChatsController.chatsControllerUnarchiveChat).toHaveBeenCalledWith(
         "test-session",
         "123@c.us"
       )
     })
 
-    it("should return false on error", async () => {
+    it("should throw NetworkError on error", async () => {
       mockChatsController.chatsControllerUnarchiveChat.mockRejectedValueOnce(new Error("API Error"))
 
-      const result = await unarchiveChat("123@c.us")
-
-      expect(result).toBe(false)
+      await expect(() => unarchiveChat("123@c.us")).toThrow(NetworkError)
     })
   })
 
   describe("markChatUnread", () => {
     it("should mark chat as unread successfully", async () => {
-      const result = await markChatUnread("123@c.us")
+      await markChatUnread("123@c.us")
 
-      expect(result).toBe(true)
       expect(mockChatsController.chatsControllerUnreadChat).toHaveBeenCalledWith(
         "test-session",
         "123@c.us"
       )
     })
 
-    it("should return false on error", async () => {
+    it("should throw NetworkError on error", async () => {
       mockChatsController.chatsControllerUnreadChat.mockRejectedValueOnce(new Error("API Error"))
 
-      const result = await markChatUnread("123@c.us")
-
-      expect(result).toBe(false)
+      await expect(() => markChatUnread("123@c.us")).toThrow(NetworkError)
     })
   })
 
   describe("deleteChat", () => {
     it("should delete a chat successfully", async () => {
-      const result = await deleteChat("123@c.us")
+      await deleteChat("123@c.us")
 
-      expect(result).toBe(true)
       expect(mockChatsController.chatsControllerDeleteChat).toHaveBeenCalledWith(
         "test-session",
         "123@c.us"
       )
     })
 
-    it("should return false on error", async () => {
+    it("should throw NetworkError on error", async () => {
       mockChatsController.chatsControllerDeleteChat.mockRejectedValueOnce(new Error("API Error"))
 
-      const result = await deleteChat("123@c.us")
-
-      expect(result).toBe(false)
+      await expect(() => deleteChat("123@c.us")).toThrow(NetworkError)
     })
   })
 })

--- a/src/client/chatActions.ts
+++ b/src/client/chatActions.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ChatId } from "../types"
+import { NetworkError } from "../services/Errors"
 import { errorService } from "../services/ErrorService"
 import { debugLog } from "../utils/debug"
 import { getClient, getSession } from "./core"
@@ -11,79 +12,91 @@ import { getClient, getSession } from "./core"
 /**
  * Archive a chat.
  * @param chatId - The chat ID to archive
- * @returns True if successful, false otherwise
+ * @throws {NetworkError} If network connection fails
+ * @throws {AuthError} If authentication fails
+ * @throws {ServerError} If server error occurs
  */
 
-export async function archiveChat(chatId: ChatId): Promise<boolean> {
+export async function archiveChat(chatId: ChatId): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Archiving chat: ${chatId}`)
     const wahaClient = getClient()
     await wahaClient.chats.chatsControllerArchiveChat(session, chatId)
     debugLog("Client", `Chat archived successfully: ${chatId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "archiveChat", chatId } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to archive chat", { chatId }, error)
+      : new NetworkError("Failed to archive chat", { chatId })
   }
 }
 
 /**
  * Unarchive a chat.
  * @param chatId - The chat ID to unarchive
- * @returns True if successful, false otherwise
+ * @throws {NetworkError} If network connection fails
+ * @throws {AuthError} If authentication fails
+ * @throws {ServerError} If server error occurs
  */
 
-export async function unarchiveChat(chatId: ChatId): Promise<boolean> {
+export async function unarchiveChat(chatId: ChatId): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Unarchiving chat: ${chatId}`)
     const wahaClient = getClient()
     await wahaClient.chats.chatsControllerUnarchiveChat(session, chatId)
     debugLog("Client", `Chat unarchived successfully: ${chatId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "unarchiveChat", chatId } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to unarchive chat", { chatId }, error)
+      : new NetworkError("Failed to unarchive chat", { chatId })
   }
 }
 
 /**
  * Mark a chat as unread.
  * @param chatId - The chat ID to mark unread
- * @returns True if successful, false otherwise
+ * @throws {NetworkError} If network connection fails
+ * @throws {AuthError} If authentication fails
+ * @throws {ServerError} If server error occurs
  */
 
-export async function markChatUnread(chatId: ChatId): Promise<boolean> {
+export async function markChatUnread(chatId: ChatId): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Marking chat as unread: ${chatId}`)
     const wahaClient = getClient()
     await wahaClient.chats.chatsControllerUnreadChat(session, chatId)
     debugLog("Client", `Chat marked as unread: ${chatId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "markChatUnread", chatId } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to mark chat as unread", { chatId }, error)
+      : new NetworkError("Failed to mark chat as unread", { chatId })
   }
 }
 
 /**
  * Delete a chat permanently.
  * @param chatId - The chat ID to delete
- * @returns True if successful, false otherwise
+ * @throws {NetworkError} If network connection fails
+ * @throws {AuthError} If authentication fails
+ * @throws {ServerError} If server error occurs
  */
 
-export async function deleteChat(chatId: ChatId): Promise<boolean> {
+export async function deleteChat(chatId: ChatId): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Deleting chat: ${chatId}`)
     const wahaClient = getClient()
     await wahaClient.chats.chatsControllerDeleteChat(session, chatId)
     debugLog("Client", `Chat deleted successfully: ${chatId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "deleteChat", chatId } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to delete chat", { chatId }, error)
+      : new NetworkError("Failed to delete chat", { chatId })
   }
 }

--- a/src/client/messageActions.ts
+++ b/src/client/messageActions.ts
@@ -6,6 +6,7 @@
 import type { WAMessage } from "@muhammedaksam/waha-node"
 
 import type { ChatId, MessageId, WAMessageExtended } from "../types"
+import { NetworkError } from "../services/Errors"
 import { errorService } from "../services/ErrorService"
 import { RetryPresets, withRetry } from "../services/RetryService"
 import { appState } from "../state/AppState"
@@ -16,15 +17,17 @@ import { getClient, getSession } from "./core"
 /**
  * Star or unstar a message.
  * @param messageId - The message ID to star/unstar
- * @param chatId - The chat containing the message
+ * @param chatId - The chat containing message
  * @param star - True to star, false to unstar
- * @returns True if successful, false otherwise
+ * @throws {NetworkError} If network connection fails
+ * @throws {AuthError} If authentication fails
+ * @throws {ServerError} If server error occurs
  */
 export async function starMessage(
   messageId: MessageId,
   chatId: ChatId,
   star: boolean
-): Promise<boolean> {
+): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `${star ? "Starring" : "Unstarring"} message: ${messageId}`)
@@ -36,10 +39,15 @@ export async function starMessage(
       star,
     })
     debugLog("Client", `Message ${star ? "starred" : "unstarred"}: ${messageId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "starMessage", messageId, star } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError(
+          `Failed to ${star ? "star" : "unstar"} message`,
+          { messageId, star },
+          error
+        )
+      : new NetworkError(`Failed to ${star ? "star" : "unstar"} message`, { messageId, star })
   }
 }
 
@@ -48,13 +56,15 @@ export async function starMessage(
  * @param chatId - The chat ID
  * @param messageId - The message ID to pin
  * @param duration - Pin duration in seconds (default: 7 days)
- * @returns True if successful, false otherwise
+ * @throws {NetworkError} If network connection fails
+ * @throws {AuthError} If authentication fails
+ * @throws {ServerError} If server error occurs
  */
 export async function pinMessage(
   chatId: ChatId,
   messageId: MessageId,
   duration: number = 604800 // 7 days in seconds (default)
-): Promise<boolean> {
+): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Pinning message: ${messageId}`)
@@ -63,10 +73,11 @@ export async function pinMessage(
       duration,
     })
     debugLog("Client", `Message pinned: ${messageId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "pinMessage", messageId } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to pin message", { messageId }, error)
+      : new NetworkError("Failed to pin message", { messageId })
   }
 }
 
@@ -74,19 +85,22 @@ export async function pinMessage(
  * Unpin a previously pinned message.
  * @param chatId - The chat ID
  * @param messageId - The message ID to unpin
- * @returns True if successful, false otherwise
+ * @throws {NetworkError} If network connection fails
+ * @throws {AuthError} If authentication fails
+ * @throws {ServerError} If server error occurs
  */
-export async function unpinMessage(chatId: ChatId, messageId: MessageId): Promise<boolean> {
+export async function unpinMessage(chatId: ChatId, messageId: MessageId): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Unpinning message: ${messageId}`)
     const wahaClient = getClient()
     await wahaClient.chats.chatsControllerUnpinMessage(session, chatId, messageId)
     debugLog("Client", `Message unpinned: ${messageId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "unpinMessage", messageId } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to unpin message", { messageId }, error)
+      : new NetworkError("Failed to unpin message", { messageId })
   }
 }
 
@@ -94,19 +108,22 @@ export async function unpinMessage(chatId: ChatId, messageId: MessageId): Promis
  * Delete a message from a chat.
  * @param chatId - The chat ID
  * @param messageId - The message ID to delete
- * @returns True if successful, false otherwise
+ * @throws {NetworkError} If network connection fails
+ * @throws {AuthError} If authentication fails
+ * @throws {ServerError} If server error occurs
  */
-export async function deleteMessage(chatId: ChatId, messageId: MessageId): Promise<boolean> {
+export async function deleteMessage(chatId: ChatId, messageId: MessageId): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Deleting message: ${messageId}`)
     const wahaClient = getClient()
     await wahaClient.chats.chatsControllerDeleteMessage(session, chatId, messageId)
     debugLog("Client", `Message deleted: ${messageId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "deleteMessage", messageId } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to delete message", { messageId }, error)
+      : new NetworkError("Failed to delete message", { messageId })
   }
 }
 
@@ -114,7 +131,7 @@ export async function forwardMessage(
   chatId: ChatId,
   messageId: MessageId,
   toChatId: ChatId
-): Promise<boolean> {
+): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Forwarding message ${messageId} to ${toChatId}`)
@@ -125,14 +142,15 @@ export async function forwardMessage(
       messageId,
     })
     debugLog("Client", `Message forwarded: ${messageId} -> ${toChatId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "forwardMessage", messageId, toChatId } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to forward message", { messageId, toChatId }, error)
+      : new NetworkError("Failed to forward message", { messageId, toChatId })
   }
 }
 
-export async function reactToMessage(messageId: string, reaction: string): Promise<boolean> {
+export async function reactToMessage(messageId: string, reaction: string): Promise<void> {
   try {
     const session = getSession()
     debugLog("Client", `Reacting to message ${messageId} with ${reaction}`)
@@ -143,10 +161,11 @@ export async function reactToMessage(messageId: string, reaction: string): Promi
       reaction,
     })
     debugLog("Client", `Reaction set: ${reaction} on ${messageId}`)
-    return true
   } catch (error) {
     errorService.handle(error, { context: { action: "reactToMessage", messageId, reaction } })
-    return false
+    throw error instanceof Error
+      ? new NetworkError("Failed to set reaction", { messageId, reaction }, error)
+      : new NetworkError("Failed to set reaction", { messageId, reaction })
   }
 }
 
@@ -268,7 +287,7 @@ export async function sendMessage(
   chatId: string,
   text: string,
   replyToMsgId?: string
-): Promise<boolean> {
+): Promise<void> {
   try {
     const session = getSession()
     debugLog(
@@ -290,11 +309,13 @@ export async function sendMessage(
 
     await loadMessages(chatId)
     appState.setIsSending(false)
-    return true
   } catch (error) {
     debugLog("Messages", `Failed to send message: ${error}`)
     appState.setIsSending(false)
-    return false
+    errorService.handle(error, { context: { action: "sendMessage", chatId, replyToMsgId } })
+    throw error instanceof Error
+      ? new NetworkError("Failed to send message", { chatId }, error)
+      : new NetworkError("Failed to send message", { chatId })
   }
 }
 

--- a/src/services/ErrorService.ts
+++ b/src/services/ErrorService.ts
@@ -4,6 +4,7 @@
  */
 
 import { debugLog } from "../utils/debug"
+import { BaseAppError } from "./Errors"
 
 /**
  * Error severity levels
@@ -87,6 +88,15 @@ class ErrorService {
    */
   classify(error: unknown, context?: Record<string, unknown>): AppError {
     const timestamp = new Date()
+
+    // Handle custom error classes first
+    if (error instanceof BaseAppError) {
+      const appError = error.toAppError()
+      if (context) {
+        appError.context = { ...appError.context, ...context }
+      }
+      return appError
+    }
 
     // Handle axios/fetch network errors
     if (this.isNetworkError(error)) {

--- a/src/services/Errors.ts
+++ b/src/services/Errors.ts
@@ -1,0 +1,214 @@
+import type { AppError, ErrorCategory, ErrorSeverity } from "./ErrorService"
+
+/**
+ * Base class for all custom application errors
+ * Provides structured error information and better type safety
+ */
+export abstract class BaseAppError extends Error implements AppError {
+  readonly code: string
+  readonly severity: ErrorSeverity
+  readonly category: ErrorCategory
+  readonly timestamp: Date
+  readonly recoverable: boolean
+  readonly recoveryAction?: string
+  readonly context?: Record<string, unknown>
+
+  constructor(
+    code: string,
+    message: string,
+    category: ErrorCategory,
+    severity: ErrorSeverity,
+    recoverable: boolean,
+    recoveryAction?: string,
+    context?: Record<string, unknown>,
+    cause?: unknown
+  ) {
+    super(message, { cause: cause instanceof Error ? cause : undefined })
+    this.name = this.constructor.name
+    this.code = code
+    this.category = category
+    this.severity = severity
+    this.recoverable = recoverable
+    this.recoveryAction = recoveryAction
+    this.context = context
+    this.timestamp = new Date()
+
+    Error.captureStackTrace?.(this, this.constructor)
+  }
+
+  get cause(): Error | undefined {
+    return super.cause instanceof Error ? super.cause : undefined
+  }
+
+  toAppError(): AppError {
+    return {
+      code: this.code,
+      message: this.message,
+      severity: this.severity,
+      category: this.category,
+      cause: this.cause,
+      context: this.context,
+      timestamp: this.timestamp,
+      recoverable: this.recoverable,
+      recoveryAction: this.recoveryAction,
+    }
+  }
+}
+
+export class NetworkError extends BaseAppError {
+  constructor(
+    message: string = "Unable to connect. Please check your network connection.",
+    context?: Record<string, unknown>,
+    cause?: Error
+  ) {
+    super(
+      "NETWORK_ERROR",
+      message,
+      "network",
+      "error",
+      true,
+      "Check your internet connection and try again",
+      context,
+      cause
+    )
+  }
+}
+
+export class AuthError extends BaseAppError {
+  constructor(
+    message: string = "Authentication failed. Please re-authenticate.",
+    context?: Record<string, unknown>,
+    cause?: Error
+  ) {
+    super(
+      "AUTH_ERROR",
+      message,
+      "auth",
+      "error",
+      true,
+      "Re-authenticate with WAHA server",
+      context,
+      cause
+    )
+  }
+}
+
+export class ValidationError extends BaseAppError {
+  constructor(message: string, field?: string, context?: Record<string, unknown>, cause?: unknown) {
+    super(
+      "VALIDATION_ERROR",
+      message,
+      "validation",
+      "warning",
+      true,
+      "Check your input and try again",
+      { ...context, field },
+      cause
+    )
+  }
+}
+
+export class StateError extends BaseAppError {
+  constructor(message: string, context?: Record<string, unknown>, cause?: Error) {
+    super(
+      "STATE_ERROR",
+      message,
+      "state",
+      "error",
+      false,
+      "Restart the application",
+      context,
+      cause
+    )
+  }
+}
+
+export class NotFoundError extends BaseAppError {
+  constructor(resource: string, id: string, context?: Record<string, unknown>, cause?: Error) {
+    super(
+      "NOT_FOUND",
+      `${resource} '${id}' not found`,
+      "api",
+      "warning",
+      false,
+      undefined,
+      { ...context, resource, id },
+      cause
+    )
+  }
+}
+
+export class ServerError extends BaseAppError {
+  constructor(
+    message: string = "Server error. Please try again later.",
+    statusCode?: number,
+    context?: Record<string, unknown>,
+    cause?: Error
+  ) {
+    super(
+      "SERVER_ERROR",
+      message,
+      "api",
+      "error",
+      true,
+      "Wait a moment and try again",
+      { ...context, statusCode },
+      cause
+    )
+  }
+}
+
+export class RateLimitError extends BaseAppError {
+  constructor(
+    message: string = "Too many requests. Please slow down.",
+    retryAfter?: number,
+    context?: Record<string, unknown>,
+    cause?: Error
+  ) {
+    super(
+      "RATE_LIMIT_ERROR",
+      message,
+      "api",
+      "warning",
+      true,
+      `Wait ${retryAfter || "a few"} seconds before trying again`,
+      { ...context, retryAfter },
+      cause
+    )
+  }
+}
+
+export class ConfigurationError extends BaseAppError {
+  constructor(
+    message: string,
+    configKey?: string,
+    context?: Record<string, unknown>,
+    cause?: Error
+  ) {
+    super(
+      "CONFIG_ERROR",
+      message,
+      "validation",
+      "error",
+      false,
+      "Check your configuration and try again",
+      { ...context, configKey },
+      cause
+    )
+  }
+}
+
+export class WebSocketError extends BaseAppError {
+  constructor(message: string, context?: Record<string, unknown>, cause?: Error) {
+    super(
+      "WEBSOCKET_ERROR",
+      message,
+      "network",
+      "error",
+      true,
+      "WebSocket connection will reconnect automatically",
+      context,
+      cause
+    )
+  }
+}

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -116,6 +116,7 @@ export class WebSocketService {
 
       this.ws = new WebSocket(fullUrl)
 
+      // Store bound handlers for cleanup
       this.ws.onopen = this.handleOpen.bind(this)
       this.ws.onmessage = this.handleMessage.bind(this)
       this.ws.onclose = this.handleClose.bind(this)
@@ -130,11 +131,22 @@ export class WebSocketService {
 
   public disconnect() {
     this.shouldKeyReconnect = false
+
+    // Clear reconnect timer
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
     }
+
+    // Clean up WebSocket connection
     if (this.ws) {
+      // Clear event handlers before closing
+      this.ws.onopen = null
+      this.ws.onmessage = null
+      this.ws.onclose = null
+      this.ws.onerror = null
+
+      // Close connection
       this.ws.close(CLOSE_NORMAL, "App closed")
       this.ws = null
     }

--- a/src/views/ConversationView.ts
+++ b/src/views/ConversationView.ts
@@ -506,13 +506,11 @@ export function ConversationView() {
           const replyMsg = currentState.replyingToMessage as { id?: string } | null
           const replyToId = replyMsg?.id
 
-          const success = await sendMessage(currentState.currentChatId, text, replyToId)
-          if (success) {
-            messageInputComponent.setText("")
-            appState.setMessageInput("")
-            // Reset height via state
-            appState.setInputHeight(MIN_INPUT_HEIGHT)
-          }
+          await sendMessage(currentState.currentChatId, text, replyToId)
+          messageInputComponent.setText("")
+          appState.setMessageInput("")
+          // Reset height via state
+          appState.setInputHeight(MIN_INPUT_HEIGHT)
         }
       }
     }
@@ -716,6 +714,26 @@ export function destroyConversationScrollBox(): void {
     }
     messageInputComponent = null
   }
+  // Cleanup input container and scrollbar
+  if (inputContainer) {
+    if (!inputContainer.isDestroyed) {
+      inputContainer.destroy()
+    }
+    inputContainer = null
+  }
+  if (inputScrollBar) {
+    if (!inputScrollBar.isDestroyed) {
+      inputScrollBar.destroy()
+    }
+    inputScrollBar = null
+  }
+  // Clear typing timeout
+  if (typingTimeout) {
+    clearTimeout(typingTimeout)
+    typingTimeout = null
+  }
+  // Reset enter send tracking
+  lastEnterIsSend = null
 }
 
 // Scroll the conversation by a given amount (for keyboard navigation)


### PR DESCRIPTION
## Summary

- Add custom error classes (NetworkError, AuthError, ValidationError, etc.)
- Migrate client functions from Promise<boolean> returns to throwing typed errors
- Update ErrorService to recognize custom error classes
- Fix event listener memory leak in config wizard (index.ts)
- Add proper cleanup for ConversationView module-level state
- Add proper cleanup for WebSocket event listeners
- Update tests to expect errors instead of boolean returns

## Breaking Changes

- Client action functions now throw typed errors instead of returning boolean
- Test assertions updated to use toThrow() instead of checking boolean returns