### PR TITLE
feat: migrate to @opentui-ui/toast

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@muhammedaksam/waha-tui",
       "dependencies": {
         "@muhammedaksam/waha-node": "2025.12.2-dev.1",
+        "@opentui-ui/toast": "^0.0.3",
         "@opentui/core": "^0.1.63",
         "node-notifier": "^10.0.1",
         "qrcode": "^1.5.4",
@@ -180,6 +181,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@muhammedaksam/waha-node": ["@muhammedaksam/waha-node@2025.12.2-dev.1", "", { "dependencies": { "axios": "^1.13.2" } }, "sha512-RHBQhdyXhU6SGwlo2PzUgyHGnHFwMibLddeMHlIwHNJD+jkTgmTIRF/MwjNyA17HRSXpwQSN0MQL8m0rxOWBag=="],
+
+    "@opentui-ui/toast": ["@opentui-ui/toast@0.0.3", "", { "peerDependencies": { "@opentui/core": "^0.1.63", "@opentui/react": "^0.1.63", "@opentui/solid": "^0.1.63" }, "optionalPeers": ["@opentui/react", "@opentui/solid"] }, "sha512-SraqA70A0rgu5+uaG7AIrdu3AyE5VbUsL/NzQ3XXUbyGHg5pwpDVQ5s//TkEpjUPf73tXZ3O76m5CJOB9OPLoQ=="],
 
     "@opentui/core": ["@opentui/core@0.1.63", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.63", "@opentui/core-darwin-x64": "0.1.63", "@opentui/core-linux-arm64": "0.1.63", "@opentui/core-linux-x64": "0.1.63", "@opentui/core-win32-arm64": "0.1.63", "@opentui/core-win32-x64": "0.1.63", "bun-webgpu": "0.1.4", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-m4xZQTNCnHXWUWCnGvacJ3Gts1H2aMwP5V/puAG77SDb51jm4W/QOyqAAdgeSakkb9II+8FfUpApX7sfwRXPUg=="],
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@muhammedaksam/waha-node": "2025.12.2-dev.1",
+    "@opentui-ui/toast": "^0.0.3",
     "@opentui/core": "^0.1.63",
     "node-notifier": "^10.0.1",
     "qrcode": "^1.5.4"

--- a/src/components/Toast.ts
+++ b/src/components/Toast.ts
@@ -1,13 +1,83 @@
 /**
  * Toast Notification Component
- * Displays user-friendly error messages with optional recovery actions
+ * Using @opentui-ui/toast for beautiful sonner-inspired toast notifications
  */
 
-import { Box, Text } from "@opentui/core"
+import type { ToasterOptions } from "@opentui-ui/toast"
+
+import { toast, TOAST_DURATION } from "@opentui-ui/toast"
 
 import type { AppError } from "../services/ErrorService"
 import { WDSColors, WhatsAppTheme } from "../config/theme"
 import { TIME_MS } from "../constants"
+
+/**
+ * WhatsApp-themed toaster configuration
+ * Uses the WDS color palette for consistent styling
+ */
+export const WHATSAPP_TOASTER_CONFIG: ToasterOptions = {
+  position: "bottom-right",
+  gap: 1,
+  stackingMode: "stack",
+  maxWidth: 60,
+  offset: { right: 2, bottom: 4 },
+  icons: {
+    success: "✓",
+    error: "✕",
+    warning: "⚠",
+    info: "ℹ",
+    loading: {
+      frames: ["◜", "◠", "◝", "◞", "◡", "◟"],
+      interval: 100,
+    },
+    close: "×",
+  },
+  toastOptions: {
+    style: {
+      backgroundColor: WhatsAppTheme.panelDark,
+      foregroundColor: WhatsAppTheme.textPrimary,
+      borderColor: WhatsAppTheme.borderLight,
+      borderStyle: "rounded",
+      paddingX: 2,
+      paddingY: 0,
+    },
+    duration: 4000,
+    success: {
+      style: {
+        borderColor: WDSColors.green[400],
+        iconColor: WDSColors.green[400],
+      },
+      duration: 3000,
+    },
+    error: {
+      style: {
+        borderColor: WDSColors.red[400],
+        iconColor: WDSColors.red[400],
+      },
+      duration: 5000,
+    },
+    warning: {
+      style: {
+        borderColor: WDSColors.yellow[400],
+        iconColor: WDSColors.yellow[400],
+      },
+      duration: 4000,
+    },
+    info: {
+      style: {
+        borderColor: WDSColors.skyBlue[500],
+        iconColor: WDSColors.skyBlue[500],
+      },
+      duration: 3000,
+    },
+    loading: {
+      style: {
+        borderColor: WhatsAppTheme.textSecondary,
+        iconColor: WhatsAppTheme.green,
+      },
+    },
+  },
+}
 
 /**
  * Toast notification types with associated styling
@@ -31,140 +101,106 @@ export interface ToastConfig {
 }
 
 /**
- * Get icon for toast type
+ * Show a toast notification using @opentui-ui/toast
  */
-function getToastIcon(type: ToastType): string {
+export function showToast(
+  message: string,
+  type: ToastType = "info",
+  duration: number = TOAST_DURATION.DEFAULT
+): string | number {
+  const options = {
+    duration: duration === 0 ? Infinity : duration,
+  }
+
   switch (type) {
     case "error":
-      return "✕"
+      return toast.error(message, options)
     case "warning":
-      return "⚠"
+      return toast.warning(message, options)
     case "success":
-      return "✓"
+      return toast.success(message, options)
     case "info":
-      return "ℹ"
+    default:
+      return toast.info(message, options)
   }
 }
 
 /**
- * Get colors for toast type using WhatsApp WDS color palette
- */
-function getToastColors(type: ToastType): { bg: string; border: string } {
-  switch (type) {
-    case "error":
-      return { bg: WDSColors.red[800], border: WDSColors.red[400] }
-    case "warning":
-      return { bg: WDSColors.yellow[800], border: WDSColors.yellow[400] }
-    case "success":
-      return { bg: WDSColors.green[800], border: WDSColors.green[400] }
-    case "info":
-      return { bg: WhatsAppTheme.panelDark, border: WDSColors.emerald[500] }
-  }
-}
-
-/**
- * Convert AppError to user-friendly toast config
+ * Convert AppError to user-friendly toast and display it
  * @param error - The classified error
  * @param onRetry - Optional retry callback
- * @returns Toast configuration
  */
-export function errorToToast(error: AppError, onRetry?: () => void): ToastConfig {
-  const config: ToastConfig = {
-    message: error.message,
-    type: "error",
-    duration: TIME_MS.TOAST_ERROR_DURATION,
-  }
+export function errorToToast(error: AppError, onRetry?: () => void): void {
+  let title = "Error"
+  let description = error.message
+  let actionLabel: string | undefined
+  let actionCallback: (() => void) | undefined
 
   // Add recovery action if available
   if (error.recoverable && onRetry) {
-    config.actionText = "Retry"
-    config.onAction = onRetry
+    actionLabel = "Retry"
+    actionCallback = onRetry
   }
 
   // Use category-specific messages
   switch (error.category) {
     case "network":
-      config.message = "Connection lost. Check your internet."
+      title = "Connection Lost"
+      description = "Check your internet connection."
       if (onRetry) {
-        config.actionText = "Retry"
+        actionLabel = "Retry"
+        actionCallback = onRetry
       }
       break
     case "auth":
-      config.message = "Session expired. Please reconnect."
-      config.actionText = "Reconnect"
+      title = "Session Expired"
+      description = "Please reconnect to continue."
+      actionLabel = "Reconnect"
       break
     case "api":
       if (error.code === "SERVER_ERROR") {
-        config.message = "Server error. Try again later."
+        title = "Server Error"
+        description = "Try again later."
       }
       break
   }
 
-  return config
-}
-
-/**
- * Render a toast notification as a top-centered modal overlay
- * @param config - Toast configuration
- * @returns Box component for the toast
- */
-export function Toast(config: ToastConfig) {
-  const colors = getToastColors(config.type)
-  const icon = getToastIcon(config.type)
-
-  const message = config.actionText
-    ? `${icon}  ${config.message}  [${config.actionText}]`
-    : `${icon}  ${config.message}`
-
-  // Create a full-width container positioned at the top
-  return Box(
-    {
-      position: "absolute",
-      top: 1,
-      left: 0,
-      right: 0,
-      justifyContent: "center",
-      alignItems: "center",
-    },
-    Box(
-      {
-        borderStyle: "rounded",
-        borderColor: colors.border,
-        backgroundColor: colors.bg,
-        paddingLeft: 2,
-        paddingRight: 2,
-        paddingTop: 0,
-        paddingBottom: 0,
-      },
-      Text({ content: message })
-    )
-  )
+  // Show the toast with title + description
+  toast.error(title, {
+    description,
+    duration: TIME_MS.TOAST_ERROR_DURATION,
+    action:
+      actionLabel && actionCallback ? { label: actionLabel, onClick: actionCallback } : undefined,
+  })
 }
 
 /**
  * Create a simple error toast
  */
-export function ErrorToast(message: string) {
-  return Toast({ message, type: "error", duration: TIME_MS.TOAST_ERROR_DURATION })
+export function errorToast(description: string): string | number {
+  return toast.error("Error", { description, duration: TIME_MS.TOAST_ERROR_DURATION })
 }
 
 /**
  * Create a simple success toast
  */
-export function SuccessToast(message: string) {
-  return Toast({ message, type: "success", duration: TIME_MS.TOAST_SUCCESS_DURATION })
+export function successToast(description: string): string | number {
+  return toast.success("Success", { description, duration: TIME_MS.TOAST_SUCCESS_DURATION })
 }
 
 /**
  * Create a simple warning toast
  */
-export function WarningToast(message: string) {
-  return Toast({ message, type: "warning", duration: TIME_MS.TOAST_WARNING_DURATION })
+export function warningToast(description: string): string | number {
+  return toast.warning("Warning", { description, duration: TIME_MS.TOAST_WARNING_DURATION })
 }
 
 /**
  * Create a simple info toast
  */
-export function InfoToast(message: string) {
-  return Toast({ message, type: "info", duration: TIME_MS.TOAST_INFO_DURATION })
+export function infoToast(description: string): string | number {
+  return toast.info("Info", { description, duration: TIME_MS.TOAST_INFO_DURATION })
 }
+
+// Re-export toast utilities from the package
+export { toast, TOAST_DURATION }

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,8 +146,7 @@ async function main() {
 
   // Register toast listener for error notifications
   errorService.subscribe((error) => {
-    const toast = errorToToast(error)
-    appState.showToast(toast.message, toast.type)
+    errorToToast(error)
   })
 
   // Run migrations (e.g., move config from ~/.waha-tui to XDG location)

--- a/src/services/NetworkService.ts
+++ b/src/services/NetworkService.ts
@@ -3,6 +3,7 @@
  * Detects and manages network connectivity state
  */
 
+import { successToast, warningToast } from "../components/Toast"
 import { TIME_MS } from "../constants"
 import { appState } from "../state/AppState"
 import { debugLog } from "../utils/debug"
@@ -75,9 +76,9 @@ class NetworkService {
 
       // Show toast on status change
       if (newStatus === "offline") {
-        appState.showToast("You are offline. Some features may be unavailable.", "warning", 0)
+        warningToast("You are offline. Some features may be unavailable.")
       } else if (oldStatus === "offline" && newStatus === "online") {
-        appState.showToast("Back online!", "success", TIME_MS.TOAST_SUCCESS_DURATION)
+        successToast("Back online!")
       }
 
       // Notify listeners


### PR DESCRIPTION
- Add @opentui-ui/toast package for sonner-inspired toast notifications
- Replace custom Toast component with package-based implementation
- Add WhatsApp-themed toaster configuration (WHATSAPP_TOASTER_CONFIG)
- Update errorToToast to use title + description format
- Add helper functions: errorToast, successToast, warningToast, infoToast
- Integrate ToasterRenderable in router with bottom-right position
- Update NetworkService to use new toast API