### PR TITLE
fix: resolve update modal auto-close and add dismissal persistence

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import {
   stopPresenceManagement,
   testConnection,
 } from "./client"
-import { UpdateAvailableModal } from "./components/Modal"
 import { errorToToast } from "./components/Toast"
 import { configExists, createDefaultConfig, loadConfig, saveConfig } from "./config/manager"
 import { DEFAULT_ENV, validateConfig } from "./config/schema"
@@ -333,12 +332,7 @@ async function main() {
   try {
     const updateInfo = await checkForUpdates()
     if (updateInfo.updateAvailable) {
-      UpdateAvailableModal({
-        updateInfo: updateInfo,
-        onDismiss: () => {
-          renderApp(true)
-        },
-      })
+      appState.setUpdateModal(true, updateInfo)
     }
   } catch (error) {
     debugLog("Update", `Error checking for updates: ${error}`)

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,7 +12,7 @@ import type { AppState, ViewType } from "./state/AppState"
 import { logoutSession } from "./client"
 import { clearMenuBounds, ContextMenu, isClickOutsideContextMenu } from "./components/ContextMenu"
 import { Footer } from "./components/Footer"
-import { LogoutConfirmModal } from "./components/Modal"
+import { LogoutConfirmModal, UpdateAvailableModal } from "./components/Modal"
 import { WHATSAPP_TOASTER_CONFIG } from "./components/Toast"
 import { appState } from "./state/AppState"
 import { debugLog } from "./utils/debug"
@@ -168,6 +168,16 @@ export function createRenderApp(renderer: CliRenderer): (forceRebuild?: boolean)
         },
         onCancel: () => {
           appState.setShowLogoutModal(false)
+        },
+      })
+    }
+
+    // Render update available modal if visible
+    if (state.showUpdateModal && state.updateInfo) {
+      UpdateAvailableModal({
+        updateInfo: state.updateInfo,
+        onDismiss: () => {
+          appState.dismissUpdateModal()
         },
       })
     }

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -13,6 +13,7 @@ import type {
 } from "@muhammedaksam/waha-node"
 
 import type { WAMessageExtended } from "../types"
+import type { UpdateInfo } from "../utils/update-checker"
 import type {
   ActiveFilter,
   ActiveIcon,
@@ -37,6 +38,7 @@ import type {
 } from "./slices"
 import { TIME_MS } from "../constants"
 import { getChatIdString } from "../utils/formatters"
+import { dismissUpdate } from "../utils/update-checker"
 import {
   createAuthSlice,
   createChatSlice,
@@ -418,6 +420,18 @@ class StateManager {
   // Modal
   setShowLogoutModal(showLogoutModal: boolean): void {
     this.modalSlice.set({ showLogoutModal })
+  }
+
+  setUpdateModal(show: boolean, info?: UpdateInfo): void {
+    this.modalSlice.setUpdateModal(show, info)
+  }
+
+  dismissUpdateModal(): void {
+    const state = this.modalSlice.getState()
+    if (state.updateInfo?.latestVersion) {
+      dismissUpdate(state.updateInfo.latestVersion)
+    }
+    this.modalSlice.setUpdateModal(false)
   }
 
   setConfigStep(configStep: ConfigStep | null): void {

--- a/src/state/slices/ModalSlice.ts
+++ b/src/state/slices/ModalSlice.ts
@@ -1,6 +1,7 @@
 import type { ChatSummary, WAMessage } from "@muhammedaksam/waha-node"
 
 import type { WAMessageExtended } from "../../types"
+import type { UpdateInfo } from "../../utils/update-checker"
 import { TIME_MS } from "../../constants"
 import { SliceActions, StateSlice } from "./types"
 
@@ -39,6 +40,8 @@ export interface ToastState {
 export interface ModalState {
   contextMenu: ContextMenuState | null
   showLogoutModal: boolean
+  showUpdateModal: boolean
+  updateInfo: UpdateInfo | null
   toast: ToastState | null
   configStep: ConfigStep | null
 }
@@ -46,6 +49,8 @@ export interface ModalState {
 export const initialModalState: ModalState = {
   contextMenu: null,
   showLogoutModal: false,
+  showUpdateModal: false,
+  updateInfo: null,
   toast: null,
   configStep: null,
 }
@@ -67,6 +72,7 @@ export interface ModalActions extends SliceActions<ModalState> {
 
   // Modals
   setShowLogoutModal(showLogoutModal: boolean): void
+  setUpdateModal(show: boolean, info?: UpdateInfo): void
   setConfigStep(configStep: ConfigStep | null): void
 
   // Toast
@@ -163,6 +169,15 @@ export function createModalSlice(): StateSlice<ModalState> & ModalActions {
 
     setShowLogoutModal(showLogoutModal: boolean) {
       state = { ...state, showLogoutModal }
+      notify()
+    },
+
+    setUpdateModal(show: boolean, info?: UpdateInfo) {
+      state = {
+        ...state,
+        showUpdateModal: show,
+        updateInfo: info || state.updateInfo,
+      }
       notify()
     },
 


### PR DESCRIPTION
- Refactor Update Modal to be state-driven in AppState to prevent auto-closing.

- Implement dismissUpdateModal in AppState to handle dismissal logic.

- Update update-checker to support dismissedVersion in cache to persist dismissal.

- Clean up router.ts and remove deprecated manual rendering logic.
