### PR TITLE
feat: add ability to go back from failed connection screen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,8 +115,15 @@ async function runConfigWizard(renderer: CliRenderer): Promise<void> {
     const handleErrorRetry = (key: KeyEvent) => {
       const state = appState.getState()
       if (state.currentView !== "config" || !state.configStep) return
-      if (state.configStep.status === "error" && (key.name === "return" || key.name === "enter")) {
-        appState.setConfigStep({ ...state.configStep, step: 2, status: "input" })
+
+      if (state.configStep.status === "error") {
+        if (key.name === "return" || key.name === "enter") {
+          // Retry - go back to API Key input (Step 2)
+          appState.setConfigStep({ ...state.configStep, step: 2, status: "input" })
+        } else if (key.name === "escape") {
+          // Go back - go back to Server URL input (Step 1)
+          appState.setConfigStep({ ...state.configStep, step: 1, status: "input" })
+        }
       }
     }
 

--- a/src/views/ConfigView.ts
+++ b/src/views/ConfigView.ts
@@ -163,7 +163,7 @@ export function ConfigView() {
         }),
         Box({ height: 1 }),
         Text({
-          content: "Press Enter to retry",
+          content: "Press Enter to retry, or Esc to change server",
           fg: WhatsAppTheme.textTertiary,
         })
       )
@@ -213,8 +213,15 @@ export function ConfigView() {
         }
 
         urlInputContainer.add(urlInputComponent)
-        urlInputComponent?.focus()
-        urlInputComponent?.gotoBufferEnd()
+      }
+
+      // Always focus when in this step
+      if (urlInputComponent) {
+        // Use setTimeout to ensure it happens after render cycle interactions
+        setTimeout(() => {
+          urlInputComponent?.focus()
+          urlInputComponent?.gotoBufferEnd()
+        }, 10)
       }
 
       return Box(
@@ -286,10 +293,10 @@ export function ConfigView() {
         }
 
         apiKeyInputContainer.add(apiKeyInputComponent)
-
-        // Auto-focus
-        setTimeout(() => apiKeyInputComponent?.focus(), 100)
       }
+
+      // Auto-focus always
+      setTimeout(() => apiKeyInputComponent?.focus(), 100)
 
       return Box(
         { flexDirection: "column", alignItems: "center", gap: 1 },


### PR DESCRIPTION
This commmit implements (#51) the ability for users to navigate back to the previous configuration step when a connection fails, instead of being forced to retry or restart the application.

- Added 'Esc' key handler in  to return to Server URL input (Step 1).
- Updated  to display instruction for 'Esc' key.
- Fixed input focus issue where fields would not be editable after navigating back.

Closes #51