### PR TITLE
feat: send media messages (Phase 1.3)

### DIFF
--- a/src/client/messageActions.ts
+++ b/src/client/messageActions.ts
@@ -17,7 +17,7 @@ import { RetryPresets, withRetry } from "~/services/RetryService"
 import { appState } from "~/state/AppState"
 import { debugLog } from "~/utils/debug"
 import { getChatIdString } from "~/utils/formatters"
-import { getMediaDownloadDir, openLocalFile } from "~/utils/mediaUtils"
+import { getMediaDownloadDir, getMimeType, openLocalFile } from "~/utils/mediaUtils"
 
 /**
  * Star or unstar a message.
@@ -477,7 +477,7 @@ export async function downloadAndOpenMedia(chatId: string, messageId: string): P
       try {
         const parsed = new URL(mediaUrl)
         relativeUrl = parsed.pathname + parsed.search
-      } catch (_e) {
+      } catch {
         // Fallback to absolute if parsing fails
       }
 
@@ -511,5 +511,95 @@ export async function downloadAndOpenMedia(chatId: string, messageId: string): P
     throw error instanceof Error
       ? new NetworkError("Failed to download and open media", { messageId }, error)
       : new NetworkError("Failed to download and open media", { messageId })
+  }
+}
+
+/**
+ * Sends a media message (image, video, audio, or document) to a chat.
+ * @param chatId - The chat ID
+ * @param filePath - The absolute path to the local file
+ * @param caption - Optional caption for the media
+ * @param replyToMessageId - Optional message ID to reply to
+ */
+export async function sendMediaMessage(
+  chatId: string,
+  filePath: string,
+  caption?: string,
+  replyToMessageId?: string
+): Promise<void> {
+  try {
+    const session = getSession()
+    const wahaClient = getClient()
+    const { readFile } = await import("node:fs/promises")
+    const { basename } = await import("node:path")
+    const { existsSync } = await import("node:fs")
+
+    if (!existsSync(filePath)) {
+      throw new Error(`File not found: ${filePath}`)
+    }
+
+    const mimeType = getMimeType(filePath)
+    const filename = basename(filePath)
+
+    // Read file and convert to base64
+    const fileBuffer = await readFile(filePath)
+    const base64Data = fileBuffer.toString("base64")
+
+    const filePayload = {
+      mimetype: mimeType,
+      filename: filename,
+      data: base64Data,
+    }
+
+    debugLog("Client", `Sending media message to ${chatId}. Mimetype: ${mimeType}`)
+
+    // Route based on mimetype
+    if (mimeType.startsWith("image/")) {
+      await wahaClient.chatting.chattingControllerSendImage({
+        session,
+        chatId,
+        file: filePayload,
+        caption,
+        reply_to: replyToMessageId,
+      })
+    } else if (mimeType.startsWith("video/")) {
+      await wahaClient.chatting.chattingControllerSendVideo({
+        session,
+        chatId,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        file: filePayload as any, // VideoBinaryFile types are incorrect in the SDK
+        caption,
+        reply_to: replyToMessageId,
+        convert: false,
+      })
+    } else if (mimeType.startsWith("audio/")) {
+      await wahaClient.chatting.chattingControllerSendVoice({
+        session,
+        chatId,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        file: filePayload as any, // VoiceBinaryFile types are incorrect in the SDK
+        reply_to: replyToMessageId,
+        convert: false,
+      })
+    } else {
+      // Document / other
+      await wahaClient.chatting.chattingControllerSendFile({
+        session,
+        chatId,
+        file: filePayload,
+        caption,
+        reply_to: replyToMessageId,
+      })
+    }
+
+    debugLog("Client", `Media message sent successfully to ${chatId}`)
+
+    // Reload messages to show the new one
+    await loadMessages(chatId)
+  } catch (error) {
+    errorService.handle(error, { context: { action: "sendMediaMessage", chatId } })
+    throw error instanceof Error
+      ? new NetworkError("Failed to send media", { chatId }, error)
+      : new NetworkError("Failed to send media", { chatId })
   }
 }

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -9,6 +9,8 @@ import type { RenderContext } from "@opentui/core"
 import {
   BoxRenderable,
   fg,
+  InputRenderable,
+  InputRenderableEvents,
   link,
   t,
   TextAttributes,
@@ -367,4 +369,150 @@ export function showUpdateModal(updateInfo: UpdateInfo): void {
       appState.dismissUpdateModal()
     },
   })
+}
+
+/**
+ * Show a generic input modal
+ * Returns a promise that resolves to the input string or null if cancelled
+ */
+export function showInputModal(
+  title: string,
+  placeholder: string,
+  initialValue = ""
+): Promise<string | null> {
+  const dialogManager = getDialogManager()
+  let inputValue = initialValue
+  let resolved = false
+
+  // Set input mode BEFORE showing dialog to prevent re-render race
+  appState.setInputMode(true)
+
+  return new Promise((resolve) => {
+    const safeResolve = (value: string | null) => {
+      if (resolved) return
+      resolved = true
+      appState.setInputMode(false)
+      resolve(value)
+    }
+
+    const dialogId = dialogManager.show({
+      content: (ctx: RenderContext) => {
+        const wrapper = new BoxRenderable(ctx, {
+          flexDirection: "column",
+          width: "100%",
+        })
+
+        // Title
+        wrapper.add(
+          new TextRenderable(ctx, {
+            content: title,
+            fg: WhatsAppTheme.textPrimary,
+            attributes: TextAttributes.BOLD,
+          })
+        )
+
+        wrapper.add(new BoxRenderable(ctx, { height: 1 }))
+
+        // Input
+        const input = new InputRenderable(ctx, {
+          value: initialValue,
+          placeholder: placeholder,
+          width: "100%",
+          backgroundColor: WhatsAppTheme.inputBg,
+          focusedBackgroundColor: WhatsAppTheme.inputBg,
+          textColor: WhatsAppTheme.textPrimary,
+          focusedTextColor: WhatsAppTheme.white,
+          placeholderColor: WhatsAppTheme.textTertiary,
+          cursorColor: WhatsAppTheme.white,
+        })
+
+        input.on(InputRenderableEvents.INPUT, (val: string) => {
+          inputValue = val
+        })
+
+        input.on(InputRenderableEvents.ENTER, () => {
+          safeResolve(inputValue)
+          dialogManager.close(dialogId)
+        })
+
+        wrapper.add(input)
+
+        wrapper.add(new BoxRenderable(ctx, { height: 1 }))
+
+        // Button row
+        const buttonRow = new BoxRenderable(ctx, {
+          flexDirection: "row",
+          justifyContent: "flex-end",
+        })
+
+        // Cancel button
+        const cancelStyle = getButtonStyle("secondary")
+        const cancelBtn = new BoxRenderable(ctx, {
+          paddingLeft: 2,
+          paddingRight: 2,
+          height: 1,
+          backgroundColor: cancelStyle.bg,
+          justifyContent: "center",
+          alignItems: "center",
+          onMouse(event) {
+            if (event.type === "down" && event.button === 0) {
+              safeResolve(null)
+              dialogManager.close(dialogId)
+              event.stopPropagation()
+            }
+          },
+        })
+        cancelBtn.add(new TextRenderable(ctx, { content: "Cancel", fg: cancelStyle.fg }))
+        buttonRow.add(cancelBtn)
+
+        // OK button
+        const okStyle = getButtonStyle("primary")
+        const okBtn = new BoxRenderable(ctx, {
+          paddingLeft: 2,
+          paddingRight: 2,
+          height: 1,
+          marginLeft: 2,
+          backgroundColor: okStyle.bg,
+          justifyContent: "center",
+          alignItems: "center",
+          onMouse(event) {
+            if (event.type === "down" && event.button === 0) {
+              safeResolve(inputValue)
+              dialogManager.close(dialogId)
+              event.stopPropagation()
+            }
+          },
+        })
+        okBtn.add(new TextRenderable(ctx, { content: "OK", fg: okStyle.fg }))
+        buttonRow.add(okBtn)
+
+        wrapper.add(buttonRow)
+
+        // Auto focus input after it's rendered
+        setTimeout(() => {
+          input.focus()
+        }, 50)
+
+        return wrapper
+      },
+      size: "medium",
+      onClose: () => {
+        safeResolve(null)
+      },
+    })
+  })
+}
+
+/**
+ * Show a file picker modal asking for absolute file path
+ */
+export function showFilePickerModal(): Promise<string | null> {
+  return showInputModal("Attach File", "Enter absolute file path (e.g., /home/user/image.png)", "")
+}
+
+/**
+ * Show a caption modal
+ */
+export function showCaptionModal(): Promise<string | null> {
+  return showInputModal("Add Caption", "Enter an optional caption...", "")
 }

--- a/src/handlers/keyboardHandler.ts
+++ b/src/handlers/keyboardHandler.ts
@@ -20,8 +20,10 @@ import {
   startPresenceManagement,
   stopPresenceManagement,
 } from "~/client"
+import { downloadAndOpenMedia, sendMediaMessage } from "~/client/messageActions"
 import { getSelectedMenuItem, handleContextMenuKey } from "~/components/ContextMenu"
-import { handleLogoutConfirm } from "~/components/Modal"
+import { handleLogoutConfirm, showCaptionModal, showFilePickerModal } from "~/components/Modal"
+import { showToast } from "~/components/Toast"
 import { saveSettings } from "~/config/manager"
 import { executeContextMenuAction } from "~/handlers"
 import { webSocketService } from "~/services/WebSocketService"
@@ -458,15 +460,41 @@ async function handleConversationViewKeys(key: KeyEvent, state: AppState): Promi
           "Keyboard",
           `Shortcut 'o' pressed - downloading media for message: ${targetMessage.id}`
         )
-        // Lazy import to avoid circular dependencies
-        import("~/client").then(({ downloadAndOpenMedia }) => {
-          downloadAndOpenMedia(state.currentChatId as string, targetMessage.id).catch((err) => {
-            debugLog("Keyboard", `Failed to download media via shortcut: ${err}`)
-          })
+        downloadAndOpenMedia(state.currentChatId as string, targetMessage.id).catch((err) => {
+          debugLog("Keyboard", `Failed to download media via shortcut: ${err}`)
         })
       } else {
         debugLog("Keyboard", "No media messages found in the current chat view to open")
       }
+    }
+    return true
+  }
+
+  // 'a' key - attach media
+  if (key.name === "a" && !state.inputMode) {
+    if (state.currentChatId) {
+      debugLog(
+        "Keyboard",
+        `Shortcut 'a' pressed - attaching media for chat: ${state.currentChatId}`
+      )
+
+      showFilePickerModal().then((filePath) => {
+        if (!filePath) return // Cancelled
+
+        showCaptionModal().then((caption) => {
+          if (caption === null) return // Cancelled
+
+          showToast("Sending media...", "info")
+          sendMediaMessage(state.currentChatId as string, filePath, caption)
+            .then(() => {
+              showToast("Media sent successfully", "success")
+            })
+            .catch((err) => {
+              debugLog("Keyboard", `Failed to send media: ${err}`)
+              showToast(`Failed to send media`, "error")
+            })
+        })
+      })
     }
     return true
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -104,11 +104,11 @@ export function updateSelectionFastPath(state: AppState): void {
  * ```
  */
 export function createRenderApp(renderer: CliRenderer): (forceRebuild?: boolean) => void {
-  // Initialize the toaster and dialog container once - they manage their own lifecycle
+  // Initialize once - these persist across re-renders to maintain internal state
   let toasterInitialized = false
   let dialogContainerInitialized = false
 
-  // Create dialog manager
+  // Create dialog manager (MUST BE INITIALIZED BEFORE IT IS USED)
   dialogManager = new DialogManager(renderer)
 
   return function renderApp(forceRebuild: boolean = false): void {
@@ -120,10 +120,11 @@ export function createRenderApp(renderer: CliRenderer): (forceRebuild?: boolean)
       return
     }
 
-    // Clear previous render - remove all children (except toaster)
+    // Clear previous render - remove all children except persistent overlays
+    // DialogContainerRenderable and ToasterRenderable must NOT be removed,
+    // as removing them destroys internal state (e.g., active dialog input focus)
     const children = renderer.root.getChildren()
     for (const child of children) {
-      // Keep the toaster and dialog container renderables
       if (child instanceof ToasterRenderable) continue
       if (child instanceof DialogContainerRenderable) continue
       renderer.root.remove(child.id)
@@ -168,13 +169,8 @@ export function createRenderApp(renderer: CliRenderer): (forceRebuild?: boolean)
       renderer.root.add(contextMenuBox)
     }
 
-    // Add toaster once (it manages its own toast lifecycle)
-    if (!toasterInitialized) {
-      renderer.root.add(new ToasterRenderable(renderer, WHATSAPP_TOASTER_CONFIG))
-      toasterInitialized = true
-    }
-
-    // Add dialog container once (it manages dialogs via DialogManager)
+    // Add dialog container once - it persists and manages its own dialog lifecycle
+    // Must be added AFTER rootWrapper so it renders on top (higher z-index)
     if (!dialogContainerInitialized && dialogManager) {
       renderer.root.add(
         new DialogContainerRenderable(renderer, {
@@ -184,6 +180,13 @@ export function createRenderApp(renderer: CliRenderer): (forceRebuild?: boolean)
         })
       )
       dialogContainerInitialized = true
+    }
+
+    // Add toaster once - it persists and manages its own toast lifecycle
+    // Must be added LAST so it renders on top of everything
+    if (!toasterInitialized) {
+      renderer.root.add(new ToasterRenderable(renderer, WHATSAPP_TOASTER_CONFIG))
+      toasterInitialized = true
     }
   }
 }

--- a/src/utils/mediaUtils.ts
+++ b/src/utils/mediaUtils.ts
@@ -62,3 +62,56 @@ export async function openLocalFile(filePath: string): Promise<boolean> {
     }
   })
 }
+
+/**
+ * Common file extensions to mime types mapping
+ */
+const EXTENSION_TO_MIME: Record<string, string> = {
+  // Images
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+
+  // Video
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mkv: "video/x-matroska",
+  avi: "video/x-msvideo",
+  mov: "video/quicktime",
+
+  // Audio
+  mp3: "audio/mpeg",
+  ogg: "audio/ogg",
+  wav: "audio/wav",
+  m4a: "audio/mp4",
+  opus: "audio/ogg; codecs=opus",
+
+  // Documents
+  pdf: "application/pdf",
+  doc: "application/msword",
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xls: "application/vnd.ms-excel",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  csv: "text/csv",
+  txt: "text/plain",
+  rtf: "application/rtf",
+  zip: "application/zip",
+  tar: "application/x-tar",
+  gz: "application/gzip",
+}
+
+/**
+ * Gets the mime type for a given file path based on its extension.
+ * Defaults to "application/octet-stream" if not found.
+ */
+export function getMimeType(filePath: string): string {
+  const parts = filePath.split(".")
+  if (parts.length > 1) {
+    const ext = parts[parts.length - 1].toLowerCase()
+    return EXTENSION_TO_MIME[ext] || "application/octet-stream"
+  }
+  return "application/octet-stream"
+}


### PR DESCRIPTION
## Summary

Implements the **Send Media Messages** feature, enabling users to upload local files (images, videos, audio, documents) to WhatsApp via the WAHA API directly from the TUI.

## Changes

### New Features
- **`a` shortcut** in conversation view triggers the media attachment workflow
- **File picker modal** prompts for an absolute file path
- **Caption modal** prompts for an optional message caption
- **Mimetype detection** via extension-to-mime mapping in `mediaUtils.ts`
- **API routing** to correct WAHA endpoint based on content type (image/video/audio/document)

### Bug Fixes
- **Dialog resolve ordering**: Fixed `dialogManager.close()` triggering `onClose` synchronously, which was resolving the modal promise with `null` before the ENTER handler could resolve with the actual input value
- **Dialog persistence**: `DialogContainerRenderable` and `ToasterRenderable` are now preserved across re-renders to maintain internal state (active dialog input focus)
- **Input mode race condition**: `setInputMode(true)` is called synchronously before showing the dialog to prevent keystroke interception

## Commits
- `01cf613` feat: add mimetype detection utility for media uploads
- `92fd14b` feat: implement media upload client action
- `899623f` feat: add input modal dialogs for file picker and caption
- `68b89b0` feat: bind 'a' shortcut to media attachment workflow
- `c141c60` fix: preserve dialog and toaster state across re-renders

## Files Changed
| File | Change |
|------|--------|
| `src/utils/mediaUtils.ts` | Add `getMimeType()` with comprehensive extension mapping |
| `src/client/messageActions.ts` | Add `sendMediaMessage()` with file validation, Base64 encoding, API routing |
| `src/components/Modal.ts` | Add `showInputModal`, `showFilePickerModal`, `showCaptionModal` with safe resolve pattern |
| `src/handlers/keyboardHandler.ts` | Bind `a` key to media attachment flow with static imports |
| `src/router.ts` | Preserve dialog/toaster renderables across re-render cycles |