### PR TITLE
fix(modal): filter out groups and duplicated contacts in new chat picker

### DIFF
--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -581,7 +581,9 @@ export function showContactPickerModal(): Promise<string | null> {
         let topResultId: string | null = null
 
         const updateResults = () => {
-          resultsContainer.clear()
+          for (const child of resultsContainer.getChildren()) {
+            child.destroyRecursively()
+          }
           const contactsMap = appState.getState().allContacts
 
           let filtered: Array<{ id: string; name: string }> = []
@@ -640,7 +642,7 @@ export function showContactPickerModal(): Promise<string | null> {
           }
 
           // Request re-render of this container
-          ctx.requestLayout()
+          ctx.requestRender()
         }
 
         updateResults()

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -3,7 +3,7 @@
  * WhatsApp-themed dialogs using @opentui-ui/dialog
  */
 
-import type { DialogContainerOptions, DialogStyle } from "@opentui-ui/dialog"
+import type { DialogContainerOptions, DialogId, DialogStyle } from "@opentui-ui/dialog"
 import type { RenderContext } from "@opentui/core"
 
 import {
@@ -11,6 +11,7 @@ import {
   fg,
   InputRenderable,
   InputRenderableEvents,
+  KeyEvent,
   link,
   t,
   TextAttributes,
@@ -23,6 +24,8 @@ import { logoutSession } from "~/client"
 import { WDSColors, WhatsAppTheme } from "~/config/theme"
 import { getDialogManager } from "~/router"
 import { appState } from "~/state/AppState"
+import { getRenderer } from "~/state/RendererContext"
+import { getInitials } from "~/utils/formatters"
 
 /**
  * WhatsApp-themed dialog container configuration
@@ -522,8 +525,10 @@ export function showCaptionModal(): Promise<string | null> {
  */
 export function showContactPickerModal(): Promise<string | null> {
   const dialogManager = getDialogManager()
+  const renderer = getRenderer()
   let resolved = false
   let searchQuery = ""
+  let selectedIndex = 0
 
   // Set input mode so global keyboard handlers don't intercept typing
   appState.setInputMode(true)
@@ -533,15 +538,38 @@ export function showContactPickerModal(): Promise<string | null> {
       if (resolved) return
       resolved = true
       appState.setInputMode(false)
+      renderer.keyInput.off("keypress", handleKey)
       resolve(value)
     }
 
-    const dialogId = dialogManager.show({
+    let filtered: Array<{ id: string; name: string }> = []
+    let updateResults: () => void = () => {}
+    // eslint-disable-next-line prefer-const
+    let dialogId: DialogId | undefined
+
+    const handleKey = (key: KeyEvent) => {
+      if (filtered.length === 0) return
+
+      if (key.name === "up") {
+        selectedIndex = Math.max(0, selectedIndex - 1)
+        updateResults()
+      } else if (key.name === "down") {
+        selectedIndex = Math.min(filtered.length - 1, selectedIndex + 1)
+        updateResults()
+      } else if (key.name === "return" || key.name === "enter") {
+        // If there's a selection, use it. If not, and search is a phone number, use that.
+        if (filtered[selectedIndex] && dialogId !== undefined) {
+          safeResolve(filtered[selectedIndex].id)
+          dialogManager.close(dialogId)
+        }
+      }
+    }
+
+    dialogId = dialogManager.show({
       content: (ctx: RenderContext) => {
         const wrapper = new BoxRenderable(ctx, {
           flexDirection: "column",
           width: "100%",
-          height: 15,
         })
 
         // Title
@@ -574,19 +602,17 @@ export function showContactPickerModal(): Promise<string | null> {
         // Results Container
         const resultsContainer = new BoxRenderable(ctx, {
           flexDirection: "column",
-          flexGrow: 1,
+          height: 16, // 8 items * 2 height
         })
         wrapper.add(resultsContainer)
 
-        let topResultId: string | null = null
-
-        const updateResults = () => {
+        updateResults = () => {
           for (const child of resultsContainer.getChildren()) {
             child.destroyRecursively()
           }
           const contactsMap = appState.getState().allContacts
 
-          let filtered: Array<{ id: string; name: string }> = []
+          filtered = []
           for (const [id, name] of contactsMap.entries()) {
             if (!searchQuery.trim()) {
               filtered.push({ id, name })
@@ -603,7 +629,10 @@ export function showContactPickerModal(): Promise<string | null> {
 
           // Limit to 8 results
           filtered = filtered.slice(0, 8)
-          topResultId = filtered.length > 0 ? filtered[0].id : null
+
+          if (selectedIndex >= filtered.length) {
+            selectedIndex = Math.max(0, filtered.length - 1)
+          }
 
           if (filtered.length === 0) {
             resultsContainer.add(
@@ -614,15 +643,16 @@ export function showContactPickerModal(): Promise<string | null> {
             )
           } else {
             filtered.forEach((contact, index) => {
-              const isSelected = index === 0 // Highlight top result
+              const isSelected = index === selectedIndex
               const row = new BoxRenderable(ctx, {
                 flexDirection: "row",
-                height: 1,
+                height: 2,
                 paddingLeft: 1,
                 paddingRight: 1,
-                backgroundColor: isSelected ? WhatsAppTheme.panelLight : "transparent",
+                alignItems: "center",
+                backgroundColor: isSelected ? WhatsAppTheme.hoverBg : "transparent",
                 onMouse(event) {
-                  if (event.type === "down" && event.button === 0) {
+                  if (event.type === "down" && event.button === 0 && dialogId !== undefined) {
                     safeResolve(contact.id)
                     dialogManager.close(dialogId)
                     event.stopPropagation()
@@ -630,12 +660,35 @@ export function showContactPickerModal(): Promise<string | null> {
                 },
               })
 
-              row.add(
+              // Avatar
+              const avatarName = contact.name || "Unknown"
+              const initials = getInitials(avatarName, 2)
+              const avatar = new BoxRenderable(ctx, {
+                width: 4,
+                height: 1,
+                backgroundColor: WhatsAppTheme.green,
+                alignItems: "center",
+                justifyContent: "center",
+              })
+              avatar.add(
                 new TextRenderable(ctx, {
-                  content: contact.name || contact.id,
-                  fg: isSelected ? WhatsAppTheme.white : WhatsAppTheme.textPrimary,
+                  content: initials,
+                  fg: WhatsAppTheme.white,
                 })
               )
+              row.add(avatar)
+
+              // Name
+              const nameBox = new BoxRenderable(ctx, { paddingLeft: 1 })
+              nameBox.add(
+                new TextRenderable(ctx, {
+                  content:
+                    avatarName.length > 25 ? avatarName.substring(0, 22) + "..." : avatarName,
+                  fg: WhatsAppTheme.textPrimary,
+                  attributes: TextAttributes.BOLD,
+                })
+              )
+              row.add(nameBox)
 
               resultsContainer.add(row)
             })
@@ -649,12 +702,13 @@ export function showContactPickerModal(): Promise<string | null> {
 
         input.on(InputRenderableEvents.INPUT, (val: string) => {
           searchQuery = val
+          selectedIndex = 0
           updateResults()
         })
 
         input.on(InputRenderableEvents.ENTER, () => {
-          if (topResultId) {
-            safeResolve(topResultId)
+          if (filtered.length > 0 && filtered[selectedIndex]) {
+            safeResolve(filtered[selectedIndex].id)
           } else if (searchQuery && /^[0-9+]+$/.test(searchQuery)) {
             // If it's a number, return it as the chatId (to be validated by the caller)
             const id = searchQuery.replace(/[^0-9]/g, "") + "@c.us"
@@ -662,13 +716,16 @@ export function showContactPickerModal(): Promise<string | null> {
           } else {
             safeResolve(null)
           }
-          dialogManager.close(dialogId)
+          if (dialogId !== undefined) dialogManager.close(dialogId)
         })
 
         // Auto focus input after it's rendered
         setTimeout(() => {
           input.focus()
         }, 50)
+
+        // Attach global key listener
+        renderer.keyInput.on("keypress", handleKey)
 
         return wrapper
       },

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -516,3 +516,164 @@ export function showFilePickerModal(): Promise<string | null> {
 export function showCaptionModal(): Promise<string | null> {
   return showInputModal("Add Caption", "Enter an optional caption...", "")
 }
+
+/**
+ * Show a contact picker modal to start a new chat
+ */
+export function showContactPickerModal(): Promise<string | null> {
+  const dialogManager = getDialogManager()
+  let resolved = false
+  let searchQuery = ""
+
+  // Set input mode so global keyboard handlers don't intercept typing
+  appState.setInputMode(true)
+
+  return new Promise((resolve) => {
+    const safeResolve = (value: string | null) => {
+      if (resolved) return
+      resolved = true
+      appState.setInputMode(false)
+      resolve(value)
+    }
+
+    const dialogId = dialogManager.show({
+      content: (ctx: RenderContext) => {
+        const wrapper = new BoxRenderable(ctx, {
+          flexDirection: "column",
+          width: "100%",
+          height: 15,
+        })
+
+        // Title
+        wrapper.add(
+          new TextRenderable(ctx, {
+            content: "Start New Chat",
+            fg: WhatsAppTheme.textPrimary,
+            attributes: TextAttributes.BOLD,
+          })
+        )
+
+        wrapper.add(new BoxRenderable(ctx, { height: 1 }))
+
+        // Input
+        const input = new InputRenderable(ctx, {
+          value: searchQuery,
+          placeholder: "Search contacts...",
+          width: "100%",
+          backgroundColor: WhatsAppTheme.inputBg,
+          focusedBackgroundColor: WhatsAppTheme.inputBg,
+          textColor: WhatsAppTheme.textPrimary,
+          focusedTextColor: WhatsAppTheme.white,
+          placeholderColor: WhatsAppTheme.textTertiary,
+          cursorColor: WhatsAppTheme.white,
+        })
+
+        wrapper.add(input)
+        wrapper.add(new BoxRenderable(ctx, { height: 1 }))
+
+        // Results Container
+        const resultsContainer = new BoxRenderable(ctx, {
+          flexDirection: "column",
+          flexGrow: 1,
+        })
+        wrapper.add(resultsContainer)
+
+        let topResultId: string | null = null
+
+        const updateResults = () => {
+          resultsContainer.clear()
+          const contactsMap = appState.getState().allContacts
+
+          let filtered: Array<{ id: string; name: string }> = []
+          for (const [id, name] of contactsMap.entries()) {
+            if (!searchQuery.trim()) {
+              filtered.push({ id, name })
+            } else {
+              const q = searchQuery.toLowerCase().trim()
+              if (name.toLowerCase().includes(q) || id.toLowerCase().includes(q)) {
+                filtered.push({ id, name })
+              }
+            }
+          }
+
+          // Sort alphabetically by name
+          filtered.sort((a, b) => (a.name || "").localeCompare(b.name || ""))
+
+          // Limit to 8 results
+          filtered = filtered.slice(0, 8)
+          topResultId = filtered.length > 0 ? filtered[0].id : null
+
+          if (filtered.length === 0) {
+            resultsContainer.add(
+              new TextRenderable(ctx, {
+                content: "No contacts found",
+                fg: WhatsAppTheme.textTertiary,
+              })
+            )
+          } else {
+            filtered.forEach((contact, index) => {
+              const isSelected = index === 0 // Highlight top result
+              const row = new BoxRenderable(ctx, {
+                flexDirection: "row",
+                height: 1,
+                paddingLeft: 1,
+                paddingRight: 1,
+                backgroundColor: isSelected ? WhatsAppTheme.panelLight : "transparent",
+                onMouse(event) {
+                  if (event.type === "down" && event.button === 0) {
+                    safeResolve(contact.id)
+                    dialogManager.close(dialogId)
+                    event.stopPropagation()
+                  }
+                },
+              })
+
+              row.add(
+                new TextRenderable(ctx, {
+                  content: contact.name || contact.id,
+                  fg: isSelected ? WhatsAppTheme.white : WhatsAppTheme.textPrimary,
+                })
+              )
+
+              resultsContainer.add(row)
+            })
+          }
+
+          // Request re-render of this container
+          ctx.requestLayout()
+        }
+
+        updateResults()
+
+        input.on(InputRenderableEvents.INPUT, (val: string) => {
+          searchQuery = val
+          updateResults()
+        })
+
+        input.on(InputRenderableEvents.ENTER, () => {
+          if (topResultId) {
+            safeResolve(topResultId)
+          } else if (searchQuery && /^[0-9+]+$/.test(searchQuery)) {
+            // If it's a number, return it as the chatId (to be validated by the caller)
+            const id = searchQuery.replace(/[^0-9]/g, "") + "@c.us"
+            safeResolve(id)
+          } else {
+            safeResolve(null)
+          }
+          dialogManager.close(dialogId)
+        })
+
+        // Auto focus input after it's rendered
+        setTimeout(() => {
+          input.focus()
+        }, 50)
+
+        return wrapper
+      },
+      size: "medium",
+      onClose: () => {
+        safeResolve(null)
+      },
+    })
+  })
+}

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -614,6 +614,11 @@ export function showContactPickerModal(): Promise<string | null> {
 
           filtered = []
           for (const [id, name] of contactsMap.entries()) {
+            // Only show regular user contacts (exclude @lid duplicates and @g.us groups)
+            if (!id.endsWith("@c.us")) {
+              continue
+            }
+
             if (!searchQuery.trim()) {
               filtered.push({ id, name })
             } else {

--- a/src/components/Modal.ts
+++ b/src/components/Modal.ts
@@ -627,9 +627,6 @@ export function showContactPickerModal(): Promise<string | null> {
           // Sort alphabetically by name
           filtered.sort((a, b) => (a.name || "").localeCompare(b.name || ""))
 
-          // Limit to 8 results
-          filtered = filtered.slice(0, 8)
-
           if (selectedIndex >= filtered.length) {
             selectedIndex = Math.max(0, filtered.length - 1)
           }
@@ -642,7 +639,16 @@ export function showContactPickerModal(): Promise<string | null> {
               })
             )
           } else {
-            filtered.forEach((contact, index) => {
+            const PAGE_SIZE = 8
+            let startIndex = Math.max(0, selectedIndex - Math.floor(PAGE_SIZE / 2))
+            let endIndex = startIndex + PAGE_SIZE
+            if (endIndex > filtered.length) {
+              endIndex = filtered.length
+              startIndex = Math.max(0, endIndex - PAGE_SIZE)
+            }
+
+            for (let index = startIndex; index < endIndex; index++) {
+              const contact = filtered[index]
               const isSelected = index === selectedIndex
               const row = new BoxRenderable(ctx, {
                 flexDirection: "row",
@@ -691,7 +697,7 @@ export function showContactPickerModal(): Promise<string | null> {
               row.add(nameBox)
 
               resultsContainer.add(row)
-            })
+            }
           }
 
           // Request re-render of this container

--- a/src/handlers/keyboardHandler.ts
+++ b/src/handlers/keyboardHandler.ts
@@ -22,13 +22,19 @@ import {
 } from "~/client"
 import { downloadAndOpenMedia, sendMediaMessage } from "~/client/messageActions"
 import { getSelectedMenuItem, handleContextMenuKey } from "~/components/ContextMenu"
-import { handleLogoutConfirm, showCaptionModal, showFilePickerModal } from "~/components/Modal"
+import {
+  handleLogoutConfirm,
+  showCaptionModal,
+  showContactPickerModal,
+  showFilePickerModal,
+} from "~/components/Modal"
 import { showToast } from "~/components/Toast"
 import { saveSettings } from "~/config/manager"
 import { executeContextMenuAction } from "~/handlers"
 import { webSocketService } from "~/services/WebSocketService"
 import { appState } from "~/state/AppState"
 import { calculateChatListScrollOffset } from "~/utils/chatListScroll"
+import { startNewChat } from "~/utils/createChat"
 import { debugLog } from "~/utils/debug"
 import { filterChats, isArchived } from "~/utils/filterChats"
 import { getChatIdString } from "~/utils/formatters"
@@ -278,6 +284,18 @@ async function handleChatsViewKeys(key: KeyEvent, state: AppState): Promise<bool
     appState.setSettingsPage("main")
     appState.setSettingsSelectedIndex(0)
     appState.setLastChangeType("view")
+    return true
+  }
+
+  // 'n' key - start new chat
+  if (key.name === "n" && !state.inputMode) {
+    debugLog("Keyboard", "Opening contact picker for new chat")
+    showContactPickerModal().then(async (chatId) => {
+      if (chatId) {
+        await startNewChat(chatId)
+        appState.setSearchQuery("")
+      }
+    })
     return true
   }
 

--- a/src/views/ChatsView.ts
+++ b/src/views/ChatsView.ts
@@ -17,6 +17,7 @@ import {
 
 import type { ActiveFilter } from "~/state/AppState"
 import { Logo } from "~/components/Logo"
+import { showContactPickerModal } from "~/components/Modal"
 import { Icons, WhatsAppTheme } from "~/config/theme"
 import { appState } from "~/state/AppState"
 import { getRenderer } from "~/state/RendererContext"
@@ -83,6 +84,16 @@ export function ChatsView() {
     )
   }
 
+  const newChatBtn = Box({}, Text({ content: Icons.newChat, fg: WhatsAppTheme.textSecondary }))
+  newChatBtn.on("click", () => {
+    showContactPickerModal().then(async (chatId) => {
+      if (chatId) {
+        await startNewChat(chatId)
+        appState.setSearchQuery("")
+      }
+    })
+  })
+
   // Header Section
   const header = Box(
     {
@@ -97,7 +108,7 @@ export function ChatsView() {
     Logo({}),
     Box(
       { flexDirection: "row", gap: 1 },
-      Text({ content: Icons.newChat, fg: WhatsAppTheme.textSecondary }),
+      newChatBtn,
       Text({ content: Icons.menu, fg: WhatsAppTheme.textSecondary })
     )
   )


### PR DESCRIPTION
This PR fixes the duplicated contacts and groups appearing in the Start New Chat modal by filtering out @lid and @g.us IDs.