### PR TITLE
feat: edit sent messages with inline modal

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -21,6 +21,7 @@ export {
   pinMessage,
   unpinMessage,
   deleteMessage,
+  editMessage,
   forwardMessage,
   reactToMessage,
   loadMessages,

--- a/src/client/messageActions.ts
+++ b/src/client/messageActions.ts
@@ -158,6 +158,38 @@ export async function forwardMessage(
   }
 }
 
+/**
+ * Edit a previously sent message.
+ * Only works for messages sent by the current user (fromMe).
+ * @param chatId - The chat ID
+ * @param messageId - The message ID to edit
+ * @param newText - The new text content
+ * @throws {NetworkError} If the edit fails
+ */
+export async function editMessage(
+  chatId: ChatId,
+  messageId: MessageId,
+  newText: string
+): Promise<void> {
+  try {
+    const session = getSession()
+    debugLog("Client", `Editing message ${messageId} in ${chatId}`)
+    const wahaClient = getClient()
+    await wahaClient.chats.chatsControllerEditMessage(session, chatId, messageId, {
+      text: newText,
+    })
+    debugLog("Client", `Message edited: ${messageId}`)
+
+    // Optimistically update local state
+    appState.updateMessageBody(chatId, messageId, newText, true)
+  } catch (error) {
+    errorService.handle(error, { context: { action: "editMessage", messageId } })
+    throw error instanceof Error
+      ? new NetworkError("Failed to edit message", { messageId }, error)
+      : new NetworkError("Failed to edit message", { messageId })
+  }
+}
+
 export async function reactToMessage(messageId: string, reaction: string): Promise<void> {
   try {
     const session = getSession()

--- a/src/components/ContextMenu.ts
+++ b/src/components/ContextMenu.ts
@@ -122,15 +122,26 @@ export function getMessageMenuItems(message: WAMessage | WAMessageExtended): Con
       id: "star",
       label: isStarred ? "Unstar" : "Star",
       icon: isStarred ? Icons.starFilled : Icons.star,
-    },
-    {
-      id: "delete",
-      label: "Delete",
-      icon: Icons.delete,
-      destructive: true,
-      separator: true,
     }
   )
+
+  // Edit option: only for own text messages
+  if (message.fromMe && message.body && !message.hasMedia) {
+    items.push({
+      id: "edit",
+      label: "Edit",
+      icon: Icons.edit || "✏️",
+      separator: true,
+    })
+  }
+
+  items.push({
+    id: "delete",
+    label: "Delete",
+    icon: Icons.delete,
+    destructive: true,
+    separator: !message.fromMe, // Only show separator if edit wasn't just added
+  })
 
   return items
 }

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -255,6 +255,7 @@ export const Icons = {
   starFilled: "★",
   react: "😀",
   delete: "✕",
+  edit: "✏",
   archive: "📦",
   unread: "●",
   info: "ⓘ",

--- a/src/handlers/ContextMenuActions.ts
+++ b/src/handlers/ContextMenuActions.ts
@@ -8,6 +8,7 @@ import {
   deleteChat,
   deleteMessage,
   downloadAndOpenMedia,
+  editMessage,
   loadChats,
   loadMessages,
   markChatUnread,
@@ -17,6 +18,8 @@ import {
   unarchiveChat,
 } from "~/client"
 import { showEmojiPicker } from "~/components/EmojiPicker"
+import { showInputModal } from "~/components/Modal"
+import { showToast } from "~/components/Toast"
 import { getSettings, saveSettings } from "~/config/manager"
 import { appState } from "~/state/AppState"
 import { debugLog } from "~/utils/debug"
@@ -159,6 +162,29 @@ export async function executeContextMenuAction(
           if (state.currentChatId) {
             await deleteMessage(state.currentChatId, targetId)
             await loadMessages(state.currentChatId)
+          }
+          break
+        }
+        case "edit": {
+          const message = contextMenu.targetData as WAMessageExtended
+          if (!message?.body || !state.currentChatId) break
+
+          // Close context menu before showing modal
+          appState.closeContextMenu()
+
+          const newText = await showInputModal(
+            "Edit Message",
+            "Enter new message text...",
+            message.body
+          )
+
+          if (newText !== null && newText.trim() && newText !== message.body) {
+            try {
+              await editMessage(state.currentChatId, targetId, newText.trim())
+              showToast("Message edited", "success")
+            } catch {
+              showToast("Failed to edit message", "error")
+            }
           }
           break
         }

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -8,6 +8,7 @@ import {
   WAHAWebhookMessage,
   WAHAWebhookMessageAck,
   WAHAWebhookMessageAny,
+  WAHAWebhookMessageEdited,
   WAHAWebhookMessageReaction,
   WAHAWebhookMessageRevoked,
   WAHAWebhookSessionStatus,
@@ -312,6 +313,9 @@ export class WebSocketService {
       case "message.revoked":
         this.handleMessageRevoked(data as WAHAWebhookMessageRevoked)
         break
+      case "message.edited":
+        this.handleMessageEdited(data as WAHAWebhookMessageEdited)
+        break
       case "presence.update":
         this.handlePresenceUpdate(data as { event: "presence.update"; payload: WAHAChatPresences })
         break
@@ -480,6 +484,23 @@ export class WebSocketService {
     const state = appState.getState()
     if (state.currentChatId && revokedId) {
       appState.markMessageRevoked(state.currentChatId, revokedId)
+    }
+  }
+
+  private handleMessageEdited(data: WAHAWebhookMessageEdited) {
+    const payload = data.payload
+    if (!payload) return
+
+    // Determine chat ID: for outgoing messages (fromMe: true), use 'to'; for incoming, use 'from'
+    const chatId = payload.fromMe ? payload.to : payload.from
+    const messageId = payload.id
+    const newBody = payload.body
+
+    debugLog("WebSocket", `Message edited: ${messageId} in ${chatId}`)
+
+    const state = appState.getState()
+    if (state.currentChatId === chatId && messageId && newBody !== undefined) {
+      appState.updateMessageBody(chatId, messageId, newBody, true)
     }
   }
 

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -323,6 +323,11 @@ class StateManager {
     this.navigationSlice.set({ lastChangeType: "data" })
   }
 
+  updateMessageBody(chatId: string, messageId: string, newBody: string, isEdited?: boolean): void {
+    this.messageSlice.updateMessageBody(chatId, messageId, newBody, isEdited)
+    this.navigationSlice.set({ lastChangeType: "data" })
+  }
+
   setScrollPosition(scrollPosition: number): void {
     this.messageSlice.setScrollPosition(scrollPosition)
   }

--- a/src/state/slices/MessageSlice.ts
+++ b/src/state/slices/MessageSlice.ts
@@ -41,6 +41,7 @@ export interface MessageActions extends SliceActions<MessageState> {
     senderId?: string
   ): void
   markMessageRevoked(chatId: string, messageId: string): void
+  updateMessageBody(chatId: string, messageId: string, newBody: string, isEdited?: boolean): void
   setScrollPosition(scrollPosition: number): void
   setMessageInput(messageInput: string): void
   setInputMode(inputMode: boolean): void
@@ -255,6 +256,27 @@ export function createMessageSlice(): StateSlice<MessageState> & MessageActions 
       const isLoadingMore = new Map(state.isLoadingMore)
       isLoadingMore.set(chatId, isLoading)
       state = { ...state, isLoadingMore }
+      notify()
+    },
+
+    updateMessageBody(chatId: string, messageId: string, newBody: string, isEdited?: boolean) {
+      const messages = new Map(state.messages)
+      const chatMessages = messages.get(chatId)
+      if (!chatMessages) return
+
+      const msgIndex = chatMessages.findIndex((m) => m.id === messageId)
+      if (msgIndex === -1) return
+
+      const updatedMsg = {
+        ...chatMessages[msgIndex],
+        body: newBody,
+        ...(isEdited ? { isEdited: true } : {}),
+      }
+      const newChatMessages = [...chatMessages]
+      newChatMessages[msgIndex] = updatedMsg
+
+      messages.set(chatId, newChatMessages)
+      state = { ...state, messages }
       notify()
     },
   }

--- a/src/types/WAMessageExtended.ts
+++ b/src/types/WAMessageExtended.ts
@@ -3,6 +3,7 @@ import type { WAMessage } from "@muhammedaksam/waha-node"
 export type WAMessageExtended = Omit<WAMessage, "participant" | "_data" | "replyTo"> & {
   participant?: string
   isForwarded?: boolean
+  isEdited?: boolean
   _data?: {
     notifyName?: string
     pushName?: string

--- a/src/views/conversation/MessageRenderer.ts
+++ b/src/views/conversation/MessageRenderer.ts
@@ -94,7 +94,9 @@ export function renderMessage(
     messageText = message.body || ""
   }
 
-  const timestampText = t`${timestamp}${isFromMe ? formatAckStatus(message.ack, {}) : ""}`
+  const isEdited = (message as WAMessageExtended).isEdited === true
+  const editedLabel = isEdited ? "edited " : ""
+  const timestampText = t`${editedLabel}${timestamp}${isFromMe ? formatAckStatus(message.ack, {}) : ""}`
 
   // Create outer row container
   const row = new BoxRenderable(renderer, {


### PR DESCRIPTION
## Phase 2.1 — Edit Sent Messages

- Add `editMessage()` API client using `chatsControllerEditMessage`
- Add `updateMessageBody()` to MessageSlice for updating message text and `isEdited` flag
- Handle `message.edited` WebSocket event for real-time edits
- Add 'Edit' context menu option (only for own text messages)
- Use `showInputModal` with pre-filled text for inline editing
- Show 'edited' label before timestamp on edited messages
- Add ✏ edit icon to theme Icons