### PR TITLE
feat: distinguish 'Delete for me' vs 'Delete for everyone'

### DIFF
--- a/src/components/ContextMenu.ts
+++ b/src/components/ContextMenu.ts
@@ -124,6 +124,28 @@ export function getMessageMenuItems(message: WAMessage | WAMessageExtended): Con
       icon: isStarred ? Icons.starFilled : Icons.star,
     }
   )
+  // Delete options: "Delete for everyone" only for own messages within 48h window
+  const DELETE_FOR_EVERYONE_WINDOW_S = 48 * 60 * 60 // 48 hours in seconds
+  const messageAge = Math.floor(Date.now() / 1000) - (message.timestamp || 0)
+  const canDeleteForEveryone = message.fromMe && messageAge < DELETE_FOR_EVERYONE_WINDOW_S
+
+  if (canDeleteForEveryone) {
+    items.push({
+      id: "delete-for-everyone",
+      label: "Delete for everyone",
+      icon: Icons.delete,
+      destructive: true,
+      separator: true,
+    })
+  }
+
+  items.push({
+    id: "delete",
+    label: "Delete for me",
+    icon: Icons.delete,
+    destructive: true,
+    separator: !canDeleteForEveryone, // Only show separator if "delete for everyone" wasn't just added
+  })
 
   // Edit option: only for own text messages
   if (message.fromMe && message.body && !message.hasMedia) {

--- a/src/handlers/ContextMenuActions.ts
+++ b/src/handlers/ContextMenuActions.ts
@@ -161,6 +161,7 @@ export async function executeContextMenuAction(
         case "delete": {
           if (state.currentChatId) {
             await deleteMessage(state.currentChatId, targetId)
+            // For "delete for me", just remove from the local message list
             await loadMessages(state.currentChatId)
           }
           break
@@ -185,6 +186,14 @@ export async function executeContextMenuAction(
             } catch {
               showToast("Failed to edit message", "error")
             }
+          }
+          break
+        }
+        case "delete-for-everyone": {
+          if (state.currentChatId) {
+            await deleteMessage(state.currentChatId, targetId)
+            // Optimistically show the revoked placeholder
+            appState.markMessageRevoked(state.currentChatId, targetId)
           }
           break
         }


### PR DESCRIPTION
## Phase 2.2 — Delete for Everyone

- Split single 'Delete' into 'Delete for me' (always available) and 'Delete for everyone' (only for own messages within 48h window)
- Add time-limit check using `message.timestamp` vs current time
- 'Delete for everyone' optimistically shows revoked placeholder
- 'Delete for me' removes from local list and reloads messages