### PR TITLE
feat: in-chat message search with highlighting

### DIFF
--- a/src/handlers/keyboardHandler.ts
+++ b/src/handlers/keyboardHandler.ts
@@ -458,6 +458,16 @@ async function handleChatsViewKeys(key: KeyEvent, state: AppState): Promise<bool
 async function handleConversationViewKeys(key: KeyEvent, state: AppState): Promise<boolean> {
   if (state.currentView !== "conversation") return false
 
+  // When search is active, handle navigation keys
+  if (state.isSearchActive) {
+    if (key.name === "return" || key.name === "enter") {
+      // Enter: next result, Shift+Enter: previous result
+      const direction = key.shift ? -1 : 1
+      appState.navigateMessageSearchResult(direction)
+      return true
+    }
+  }
+
   // 'm' key - open message context menu
   if (key.name === "m" && !state.inputMode) {
     const messages = state.messages.get(state.currentChatId || "")
@@ -572,9 +582,23 @@ async function handleConversationViewKeys(key: KeyEvent, state: AppState): Promi
     return true
   }
 
+  // '/' or Ctrl+F — open in-chat search
+  if (
+    (!state.inputMode && !state.isSearchActive && key.sequence === "/") ||
+    (key.ctrl && key.name === "f")
+  ) {
+    debugLog("Keyboard", "Conversation: Opening in-chat search")
+    appState.setMessageSearchActive(true)
+    appState.setInputMode(true)
+    return true
+  }
+
   // Escape key
   if (key.name === "escape") {
-    if (state.inputMode) {
+    if (state.isSearchActive) {
+      appState.clearMessageSearch()
+      appState.setInputMode(false)
+    } else if (state.inputMode) {
       blurMessageInput()
     } else {
       stopPresenceManagement()

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -347,7 +347,6 @@ class StateManager {
   setInputHeight(inputHeight: number): void {
     this.messageSlice.setInputHeight(inputHeight)
   }
-
   setReplyingToMessage(message: WAMessageExtended | WAMessage | null): void {
     this.messageSlice.setReplyingToMessage(message)
   }
@@ -359,6 +358,30 @@ class StateManager {
 
   setIsLoadingMore(chatId: string, isLoading: boolean): void {
     this.messageSlice.setIsLoadingMore(chatId, isLoading)
+  }
+
+  // In-chat message search
+  setMessageSearchActive(active: boolean): void {
+    this.messageSlice.setSearchActive(active)
+    this.navigationSlice.set({ lastChangeType: "data" })
+  }
+
+  setMessageSearchQuery(query: string): void {
+    const chatId = this.getState().currentChatId
+    if (chatId) {
+      this.messageSlice.setSearchQuery(query, chatId)
+      this.navigationSlice.set({ lastChangeType: "data" })
+    }
+  }
+
+  navigateMessageSearchResult(direction: 1 | -1): void {
+    this.messageSlice.navigateSearchResult(direction)
+    this.navigationSlice.set({ lastChangeType: "data" })
+  }
+
+  clearMessageSearch(): void {
+    this.messageSlice.clearSearch()
+    this.navigationSlice.set({ lastChangeType: "data" })
   }
 
   // Navigation

--- a/src/state/slices/MessageSlice.ts
+++ b/src/state/slices/MessageSlice.ts
@@ -16,6 +16,12 @@ export interface MessageState {
   // Pagination state
   hasMoreMessages: Map<string, boolean>
   isLoadingMore: Map<string, boolean>
+
+  // In-chat search state
+  searchQuery: string
+  searchResultIndices: number[] // Indices into the current chat's messages array
+  searchActiveIndex: number // Which result is currently focused
+  isSearchActive: boolean
 }
 
 export const initialMessageState: MessageState = {
@@ -28,6 +34,10 @@ export const initialMessageState: MessageState = {
   replyingToMessage: null,
   hasMoreMessages: new Map(),
   isLoadingMore: new Map(),
+  searchQuery: "",
+  searchResultIndices: [],
+  searchActiveIndex: -1,
+  isSearchActive: false,
 }
 
 export interface MessageActions extends SliceActions<MessageState> {
@@ -52,6 +62,12 @@ export interface MessageActions extends SliceActions<MessageState> {
   // Pagination actions
   setHasMoreMessages(chatId: string, hasMore: boolean): void
   setIsLoadingMore(chatId: string, isLoading: boolean): void
+
+  // Search actions
+  setSearchActive(active: boolean): void
+  setSearchQuery(query: string, chatId: string): void
+  navigateSearchResult(direction: 1 | -1): void
+  clearSearch(): void
 }
 
 export function createMessageSlice(): StateSlice<MessageState> & MessageActions {
@@ -277,6 +293,81 @@ export function createMessageSlice(): StateSlice<MessageState> & MessageActions 
 
       messages.set(chatId, newChatMessages)
       state = { ...state, messages }
+      notify()
+    },
+
+    setSearchActive(active: boolean) {
+      if (active) {
+        state = {
+          ...state,
+          isSearchActive: true,
+          searchQuery: "",
+          searchResultIndices: [],
+          searchActiveIndex: -1,
+        }
+      } else {
+        state = {
+          ...state,
+          isSearchActive: false,
+          searchQuery: "",
+          searchResultIndices: [],
+          searchActiveIndex: -1,
+        }
+      }
+      notify()
+    },
+
+    setSearchQuery(query: string, chatId: string) {
+      if (!query.trim()) {
+        state = { ...state, searchQuery: query, searchResultIndices: [], searchActiveIndex: -1 }
+        notify()
+        return
+      }
+
+      const messages = state.messages.get(chatId) || []
+      const lowerQuery = query.toLowerCase()
+      const indices: number[] = []
+
+      for (let i = 0; i < messages.length; i++) {
+        const body = messages[i].body || ""
+        if (body.toLowerCase().includes(lowerQuery)) {
+          indices.push(i)
+        }
+      }
+
+      state = {
+        ...state,
+        searchQuery: query,
+        searchResultIndices: indices,
+        searchActiveIndex: indices.length > 0 ? indices.length - 1 : -1, // Start at the bottom-most result
+      }
+      notify()
+    },
+
+    navigateSearchResult(direction: 1 | -1) {
+      if (state.searchResultIndices.length === 0) return
+
+      let nextIndex = state.searchActiveIndex + direction
+
+      // Wrap around
+      if (nextIndex < 0) {
+        nextIndex = state.searchResultIndices.length - 1
+      } else if (nextIndex >= state.searchResultIndices.length) {
+        nextIndex = 0
+      }
+
+      state = { ...state, searchActiveIndex: nextIndex }
+      notify()
+    },
+
+    clearSearch() {
+      state = {
+        ...state,
+        isSearchActive: false,
+        searchQuery: "",
+        searchResultIndices: [],
+        searchActiveIndex: -1,
+      }
       notify()
     },
   }

--- a/src/views/ConversationView.ts
+++ b/src/views/ConversationView.ts
@@ -7,6 +7,8 @@ import {
   Box,
   BoxRenderable,
   fg,
+  InputRenderable,
+  InputRenderableEvents,
   RenderableEvents,
   ScrollBarRenderable,
   ScrollBoxRenderable,
@@ -45,6 +47,7 @@ let conversationScrollBox: ScrollBoxRenderable | null = null
 let messageInputComponent: TextareaRenderable | null = null
 let inputContainer: BoxRenderable | null = null
 let inputScrollBar: ScrollBarRenderable | null = null
+let searchInputComponent: InputRenderable | null = null
 let typingTimeout: ReturnType<typeof setTimeout> | null = null
 let lastEnterIsSend: boolean | null = null // Track enterIsSend setting to recreate input when changed
 
@@ -343,7 +346,18 @@ export function ConversationView() {
     let lastTimestamp = 0
     let lastFromMe: boolean | null = null
 
-    for (const message of reversedMessages) {
+    // Search highlighting: determine which original indices are search results
+    const searchResultSet = new Set(state.searchResultIndices)
+    const activeOriginalIndex =
+      state.isSearchActive && state.searchActiveIndex >= 0
+        ? state.searchResultIndices[state.searchActiveIndex]
+        : -1
+
+    for (let rIdx = 0; rIdx < reversedMessages.length; rIdx++) {
+      const message = reversedMessages[rIdx]
+      // Original index in the messages array (messages are oldest-first, reversed is newest-first)
+      const originalIndex = messages.length - 1 - rIdx
+
       // Date Separator
       const dateLabel = formatDateSeparator(message.timestamp)
       if (dateLabel !== lastDateLabel) {
@@ -370,21 +384,46 @@ export function ConversationView() {
 
       const isSequenceStart = senderChanged || (lastTimestamp > 0 && timeGap > 60 * 60 * 1.5)
 
-      conversationScrollBox.add(
-        renderMessage(
-          renderer,
-          message,
-          isGroup,
-          isSequenceStart,
-          participantIds,
-          state.currentChatId
-        )
+      const isSearchMatch = searchResultSet.has(originalIndex)
+      const isActiveMatch = originalIndex === activeOriginalIndex
+
+      const msgRenderable = renderMessage(
+        renderer,
+        message,
+        isGroup,
+        isSequenceStart,
+        participantIds,
+        state.currentChatId
       )
+
+      if (isSearchMatch && state.isSearchActive) {
+        // Wrap in a highlight container
+        const highlight = new BoxRenderable(renderer, {
+          id: `search-highlight-${message.id || rIdx}`,
+          border: isActiveMatch,
+          borderColor: isActiveMatch ? WhatsAppTheme.green : WhatsAppTheme.textTertiary,
+          borderStyle: "rounded",
+          backgroundColor: isActiveMatch ? "#1a332e" : "transparent",
+        })
+        highlight.add(msgRenderable)
+        conversationScrollBox.add(highlight)
+      } else {
+        conversationScrollBox.add(msgRenderable)
+      }
 
       // Update last sender, timestamp, and fromMe flag
       lastSenderId = senderId
       lastTimestamp = message.timestamp
       lastFromMe = currentFromMe
+    }
+
+    // Auto-scroll to active search result index
+    if (activeOriginalIndex >= 0 && conversationScrollBox) {
+      // Calculate approximate scroll position based on the reversed index
+      const rIdx = messages.length - 1 - activeOriginalIndex
+      // Each message is ~3 lines, plus day separators. Rough estimate:
+      const estimatedLine = Math.max(0, rIdx * 3 - 5)
+      conversationScrollBox.scrollTop = estimatedLine
     }
 
     // Add a spacer at the bottom to prevent messages from being "crushed" by the input bar
@@ -725,6 +764,79 @@ export function ConversationView() {
     replyPreviewBar.add(cancelButton)
   }
 
+  // Search bar (conditional, between header and messages)
+  let searchBar: ReturnType<typeof Box> | null = null
+  if (state.isSearchActive) {
+    // Create or reuse the search input
+    if (!searchInputComponent) {
+      searchInputComponent = new InputRenderable(renderer, {
+        value: state.searchQuery,
+        placeholder: "Search messages...",
+        width: "100%",
+        backgroundColor: WhatsAppTheme.inputBg,
+        focusedBackgroundColor: WhatsAppTheme.inputBg,
+        textColor: WhatsAppTheme.textPrimary,
+        focusedTextColor: WhatsAppTheme.white,
+        placeholderColor: WhatsAppTheme.textTertiary,
+        cursorColor: WhatsAppTheme.white,
+      })
+
+      searchInputComponent.on(InputRenderableEvents.INPUT, (val: string) => {
+        appState.setMessageSearchQuery(val)
+      })
+
+      // Auto-focus
+      setTimeout(() => {
+        searchInputComponent?.focus()
+      }, 50)
+    }
+
+    const resultCount = state.searchResultIndices.length
+    const currentIdx = state.searchActiveIndex >= 0 ? state.searchActiveIndex + 1 : 0
+    const resultLabel = state.searchQuery.trim() ? `${currentIdx}/${resultCount}` : ""
+
+    searchBar = Box(
+      {
+        height: 3,
+        flexDirection: "row",
+        alignItems: "center",
+        paddingLeft: 1,
+        paddingRight: 1,
+        backgroundColor: WhatsAppTheme.panelDark,
+        border: true,
+        borderColor: WhatsAppTheme.borderColor,
+      },
+      Box(
+        {
+          flexGrow: 1,
+          marginRight: 1,
+        },
+        searchInputComponent
+      ),
+      Text({
+        content: resultLabel,
+        fg: WhatsAppTheme.textSecondary,
+        width: 8,
+      }),
+      Text({
+        content: "↑↓",
+        fg: WhatsAppTheme.textTertiary,
+        marginLeft: 1,
+      }),
+      Text({
+        content: "ESC",
+        fg: WhatsAppTheme.textTertiary,
+        marginLeft: 1,
+      })
+    )
+  } else if (searchInputComponent) {
+    // Clean up search input when search is deactivated
+    if (!searchInputComponent.isDestroyed) {
+      searchInputComponent.destroy()
+    }
+    searchInputComponent = null
+  }
+
   return Box(
     {
       flexDirection: "column",
@@ -732,6 +844,7 @@ export function ConversationView() {
       backgroundColor: WhatsAppTheme.deepDark,
     },
     header,
+    ...(searchBar ? [searchBar] : []),
     conversationScrollBox,
     ...(replyPreviewBar ? [replyPreviewBar] : []),
     inputContainer
@@ -764,6 +877,13 @@ export function destroyConversationScrollBox(): void {
       inputScrollBar.destroy()
     }
     inputScrollBar = null
+  }
+  // Cleanup search input
+  if (searchInputComponent) {
+    if (!searchInputComponent.isDestroyed) {
+      searchInputComponent.destroy()
+    }
+    searchInputComponent = null
   }
   // Clear typing timeout
   if (typingTimeout) {


### PR DESCRIPTION
## Phase 2.3 — In-Chat Message Search

- Add search state to MessageSlice (query, result indices, active index, isSearchActive flag)
- Add search actions: `setSearchQuery` (case-insensitive matching), `navigateSearchResult` (wrapping), `clearSearch`
- Expose `MessageSearch` methods on StateManager (distinct from chat list search)
- Add `/` and `Ctrl+F` keyboard shortcuts to open search bar
- Render search input bar between header and messages with result count (`N/M`) and key hints
- Highlight matching messages with green border + tinted background for the active match
- `Enter` navigates to next result, `Shift+Enter` to previous
- `Escape` closes search and restores normal mode
- Auto-scroll to active search result position
- Cleanup search input on conversation destroy