### PR TITLE
feat: scroll-to-top auto-load with loading indicator

### DIFF
--- a/src/client/messageActions.ts
+++ b/src/client/messageActions.ts
@@ -246,49 +246,93 @@ export async function loadMessages(chatId: string): Promise<void> {
   }
 }
 
-let isLoadingMore = false
+/** Debounce timer for loadOlderMessages to prevent rapid-fire calls when scrolling */
+let loadOlderDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
+/**
+ * Load older messages for the current chat (pagination).
+ * Uses state-based `isLoadingMore` tracking so the UI can show indicators.
+ * Respects `hasMoreMessages` to avoid unnecessary API calls.
+ * Debounced to prevent rapid-fire calls when scrolling.
+ */
 export async function loadOlderMessages(): Promise<void> {
   const state = appState.getState()
-  if (!state.currentChatId || !state.currentSession || isLoadingMore) {
+  if (!state.currentChatId || !state.currentSession) {
+    return
+  }
+
+  // Guard: already loading
+  if (state.isLoadingMore.get(state.currentChatId)) {
+    return
+  }
+
+  // Guard: no more messages available
+  if (state.hasMoreMessages.get(state.currentChatId) === false) {
+    debugLog("Messages", "No more older messages (hasMoreMessages=false)")
     return
   }
 
   const currentMessages = state.messages.get(state.currentChatId) || []
   if (currentMessages.length === 0) return
 
-  isLoadingMore = true
-  const offset = currentMessages.length
-  debugLog("Messages", `Loading older messages with offset ${offset}`)
+  // Debounce: clear any pending timer and schedule a new one
+  if (loadOlderDebounceTimer) {
+    clearTimeout(loadOlderDebounceTimer)
+  }
 
-  try {
-    const wahaClient = getClient()
-    const response = await wahaClient.chats.chatsControllerGetChatMessages(
-      state.currentSession,
-      state.currentChatId,
-      {
+  const chatId = state.currentChatId
+  const session = state.currentSession
+
+  loadOlderDebounceTimer = setTimeout(async () => {
+    loadOlderDebounceTimer = null
+
+    // Re-check guards after debounce delay
+    const freshState = appState.getState()
+    if (freshState.currentChatId !== chatId) return
+    if (freshState.isLoadingMore.get(chatId)) return
+    if (freshState.hasMoreMessages.get(chatId) === false) return
+
+    const messages = freshState.messages.get(chatId) || []
+    if (messages.length === 0) return
+
+    appState.setIsLoadingMore(chatId, true)
+    const offset = messages.length
+    debugLog("Messages", `Loading older messages with offset ${offset}`)
+
+    try {
+      const wahaClient = getClient()
+      const response = await wahaClient.chats.chatsControllerGetChatMessages(session, chatId, {
         limit: 50,
         offset: offset,
         downloadMedia: false,
         sortBy: "messageTimestamp",
         sortOrder: "desc",
+      })
+
+      const newMessages = (response.data as unknown as WAMessage[]) || []
+
+      if (newMessages.length > 0) {
+        debugLog("Messages", `Loaded ${newMessages.length} older messages`)
+        // Re-fetch current messages in case they changed during the request
+        const latestMessages = appState.getState().messages.get(chatId) || []
+        const combinedMessages = [...latestMessages, ...newMessages]
+        appState.setMessages(chatId, combinedMessages)
+
+        // If we got fewer than requested, there are no more
+        if (newMessages.length < 50) {
+          appState.setHasMoreMessages(chatId, false)
+          debugLog("Messages", "Reached end of message history")
+        }
+      } else {
+        debugLog("Messages", "No more older messages available")
+        appState.setHasMoreMessages(chatId, false)
       }
-    )
-
-    const newMessages = (response.data as unknown as WAMessage[]) || []
-
-    if (newMessages.length > 0) {
-      debugLog("Messages", `Loaded ${newMessages.length} older messages`)
-      const combinedMessages = [...currentMessages, ...newMessages]
-      appState.setMessages(state.currentChatId, combinedMessages)
-    } else {
-      debugLog("Messages", "No more older messages available")
+    } catch (error) {
+      debugLog("Messages", `Failed to load older messages: ${error}`)
+    } finally {
+      appState.setIsLoadingMore(chatId, false)
     }
-  } catch (error) {
-    debugLog("Messages", `Failed to load older messages: ${error}`)
-  } finally {
-    isLoadingMore = false
-  }
+  }, 300) // 300ms debounce
 }
 
 export async function sendMessage(

--- a/src/handlers/keyboardHandler.ts
+++ b/src/handlers/keyboardHandler.ts
@@ -13,7 +13,6 @@ import {
   loadChats,
   loadContacts,
   loadMessages,
-  loadOlderMessages,
   loadSessions,
   logoutSession,
   markActivity,
@@ -542,7 +541,6 @@ async function handleConversationViewKeys(key: KeyEvent, state: AppState): Promi
   if (key.name === "up" && !state.inputMode) {
     debugLog("Keyboard", "Conversation: UP - scrolling up")
     scrollConversation(-4)
-    loadOlderMessages()
     return true
   }
 

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -347,6 +347,15 @@ class StateManager {
     this.messageSlice.setReplyingToMessage(message)
   }
 
+  // Pagination
+  setHasMoreMessages(chatId: string, hasMore: boolean): void {
+    this.messageSlice.setHasMoreMessages(chatId, hasMore)
+  }
+
+  setIsLoadingMore(chatId: string, isLoading: boolean): void {
+    this.messageSlice.setIsLoadingMore(chatId, isLoading)
+  }
+
   // Navigation
   setSelectedSessionIndex(selectedSessionIndex: number): void {
     this.navigationSlice.setSelectedSessionIndex(selectedSessionIndex)

--- a/src/views/ConversationView.ts
+++ b/src/views/ConversationView.ts
@@ -17,7 +17,7 @@ import {
   TextRenderable,
 } from "@opentui/core"
 
-import { loadChatDetails, sendMessage, sendTypingState } from "~/client"
+import { loadChatDetails, loadOlderMessages, sendMessage, sendTypingState } from "~/client"
 import { Icons, WhatsAppTheme } from "~/config/theme"
 import { TIME_MS } from "~/constants"
 import { appState } from "~/state/AppState"
@@ -291,6 +291,43 @@ export function ConversationView() {
   const existingChildren = conversationScrollBox.getChildren()
   for (const child of existingChildren) {
     conversationScrollBox.remove(child.id)
+  }
+
+  // Add loading indicator at top (shown when loading older messages)
+  const isLoadingMore = state.isLoadingMore.get(state.currentChatId) ?? false
+  const hasMoreMessages = state.hasMoreMessages.get(state.currentChatId) !== false
+
+  if (isLoadingMore) {
+    const loadingRow = new BoxRenderable(renderer, {
+      id: "loading-older-messages",
+      flexDirection: "row",
+      justifyContent: "center",
+      height: 1,
+      marginBottom: 1,
+    })
+    loadingRow.add(
+      new TextRenderable(renderer, {
+        content: "⟳ Loading older messages...",
+        fg: WhatsAppTheme.textSecondary,
+      })
+    )
+    conversationScrollBox.add(loadingRow)
+  } else if (hasMoreMessages && messages.length > 0) {
+    // Show a subtle hint that more messages can be loaded
+    const hintRow = new BoxRenderable(renderer, {
+      id: "load-more-hint",
+      flexDirection: "row",
+      justifyContent: "center",
+      height: 1,
+      marginBottom: 1,
+    })
+    hintRow.add(
+      new TextRenderable(renderer, {
+        content: "↑ Scroll up to load more",
+        fg: WhatsAppTheme.textTertiary,
+      })
+    )
+    conversationScrollBox.add(hintRow)
   }
 
   // Add messages
@@ -737,9 +774,26 @@ export function destroyConversationScrollBox(): void {
   lastEnterIsSend = null
 }
 
+/**
+ * Get the current scroll position of the conversation scroll box.
+ * Returns scrollTop value, or -1 if no scroll box exists.
+ */
+export function getConversationScrollTop(): number {
+  if (conversationScrollBox) {
+    return conversationScrollBox.scrollTop
+  }
+  return -1
+}
+
 // Scroll the conversation by a given amount (for keyboard navigation)
+// Automatically triggers loadOlderMessages when scrolled near the top
 export function scrollConversation(delta: number): void {
   if (conversationScrollBox) {
     conversationScrollBox.scrollBy(delta)
+
+    // Auto-load when scrolled near the top (within 5 lines threshold)
+    if (conversationScrollBox.scrollTop <= 5) {
+      loadOlderMessages()
+    }
   }
 }


### PR DESCRIPTION
## Phase 2.4 — Scroll-to-Top Auto-Load

- Refactored pagination: replaced naive per-keypress loading with scroll-position-based auto-trigger
- Added `isLoadingMore` / `hasMoreMessages` state tracking in MessageSlice to prevent duplicate API calls
- Show `⟳ Loading older messages...` indicator at top while fetching
- 300ms debounce on loading requests for smooth performance
- Removed manual `loadOlderMessages()` calls from UP arrow handler