### PR TITLE
feat: add pin/unpin, mute/unmute to chat context menu

### DIFF
--- a/src/components/ContextMenu.ts
+++ b/src/components/ContextMenu.ts
@@ -14,7 +14,7 @@ import { QUICK_REACTIONS } from "~/data/emojis"
 import { appState } from "~/state/AppState"
 import { getRenderer } from "~/state/RendererContext"
 import { debugLog } from "~/utils/debug"
-import { isArchived } from "~/utils/filterChats"
+import { hasUnreadMessages, isArchived, isPinned } from "~/utils/filterChats"
 
 export interface ContextMenuItem {
   id: string
@@ -26,30 +26,61 @@ export interface ContextMenuItem {
   isQuickReactions?: boolean // Indicates this is the quick reactions row
 }
 
+// Check if a chat is muted
+function isMuted(chat: ChatSummary): boolean {
+  const ext = chat as ChatSummary & { isMuted?: boolean; _chat?: { isMuted?: boolean } }
+  return ext.isMuted === true || ext._chat?.isMuted === true
+}
+
 // Chat context menu items
 export function getChatMenuItems(chat: ChatSummary): ContextMenuItem[] {
-  // Check if chat is archived using the same logic as filterChats
   const isArchivedChat = isArchived(chat)
+  const chatIsPinned = isPinned(chat)
+  const chatIsMuted = isMuted(chat)
+  const chatHasUnread = hasUnreadMessages(chat)
 
-  return [
+  const items: ContextMenuItem[] = [
     {
       id: "archive",
       label: isArchivedChat ? "Unarchive chat" : "Archive chat",
       icon: Icons.archive,
     },
     {
+      id: "pin",
+      label: chatIsPinned ? "Unpin chat" : "Pin chat",
+      icon: Icons.pin,
+    },
+    {
+      id: "mute",
+      label: chatIsMuted ? "Unmute" : "Mute",
+      icon: Icons.muted,
+    },
+  ]
+
+  // Show "Mark as read" when unread, "Mark as unread" when read
+  if (chatHasUnread) {
+    items.push({
+      id: "read",
+      label: "Mark as read",
+      icon: Icons.unread,
+    })
+  } else {
+    items.push({
       id: "unread",
       label: "Mark as unread",
       icon: Icons.unread,
-    },
-    {
-      id: "delete",
-      label: "Delete chat",
-      icon: Icons.delete,
-      destructive: true,
-      separator: true,
-    },
-  ]
+    })
+  }
+
+  items.push({
+    id: "delete",
+    label: "Delete chat",
+    icon: Icons.delete,
+    destructive: true,
+    separator: true,
+  })
+
+  return items
 }
 
 // Message context menu items

--- a/src/handlers/ContextMenuActions.ts
+++ b/src/handlers/ContextMenuActions.ts
@@ -17,6 +17,7 @@ import {
   starMessage,
   unarchiveChat,
 } from "~/client"
+import { markChatRead } from "~/client/chatActions"
 import { showEmojiPicker } from "~/components/EmojiPicker"
 import { showInputModal } from "~/components/Modal"
 import { showToast } from "~/components/Toast"
@@ -73,6 +74,20 @@ export async function executeContextMenuAction(
           await markChatUnread(targetId)
           await loadChats()
           break
+        case "read":
+          await markChatRead(targetId)
+          await loadChats()
+          break
+        case "pin": {
+          // WAHA doesn't expose a pin/unpin chat API — only message pinning is available
+          showToast("Pin/unpin chat is not supported by WAHA API", "info")
+          break
+        }
+        case "mute": {
+          // WAHA doesn't expose a mute/unmute chat API
+          showToast("Mute/unmute is not supported by WAHA API", "info")
+          break
+        }
         case "delete":
           await deleteChat(targetId)
           await loadChats()


### PR DESCRIPTION
## Phase 3.1 & 3.2 — Pin/Mute Chats

- Added 'Pin chat' / 'Unpin chat' and 'Mute' / 'Unmute' to the context menu.
- Because WAHA doesn't expose chat-level pin/mute APIs, these actions display an informative toast.
- Pin/mute indicators continue to be rendered correctly based on existing `_chat` payload data.