### PR TITLE
feat: auto-mark chat as read when opening via keyboard

### DIFF
--- a/src/handlers/keyboardHandler.ts
+++ b/src/handlers/keyboardHandler.ts
@@ -20,6 +20,7 @@ import {
   startPresenceManagement,
   stopPresenceManagement,
 } from "~/client"
+import { markChatRead } from "~/client/chatActions"
 import { downloadAndOpenMedia, reactToMessage, sendMediaMessage } from "~/client/messageActions"
 import { getSelectedContextMenuActionId, handleContextMenuKey } from "~/components/ContextMenu"
 import { showEmojiPicker } from "~/components/EmojiPicker"
@@ -349,6 +350,7 @@ async function handleChatsViewKeys(key: KeyEvent, state: AppState): Promise<bool
       loadContacts()
       await loadMessages(chatId)
       startPresenceManagement(chatId)
+      markChatRead(chatId)
     }
     return true
   }


### PR DESCRIPTION
## Phase 3.3 — Auto-mark chat as read

- Added the `markChatRead()` API call to the keyboard Enter handler.
- Fixes issue where opening a chat via keyboard navigation didn't clear the unread badge (unlike the mouse click handler which already did).