### PR TITLE
fix: pass child object instead of child.id to remove()

### DIFF
--- a/src/components/ChatPickerDialog.ts
+++ b/src/components/ChatPickerDialog.ts
@@ -86,7 +86,7 @@ export function showChatPicker(_message: WAMessageExtended): Promise<ChatSummary
       // Clear existing list
       const children = listContainer.getChildren()
       for (const child of children) {
-        listContainer.remove(child.id)
+        listContainer.remove(child)
       }
       rowRenderables.length = 0
 

--- a/src/components/EmojiPicker.ts
+++ b/src/components/EmojiPicker.ts
@@ -162,12 +162,12 @@ export function EmojiPicker(): BoxRenderable | null {
     // Clear grid
     const children = gridContainer.getChildren()
     for (const child of children) {
-      gridContainer.remove(child.id)
+      gridContainer.remove(child)
     }
 
     const tabChildren = categoriesRow.getChildren()
     for (const child of tabChildren) {
-      categoriesRow.remove(child.id)
+      categoriesRow.remove(child)
     }
 
     categoryOffsets.clear()

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ async function runConfigWizard(renderer: CliRenderer): Promise<void> {
     const renderConfigView = () => {
       const children = renderer.root.getChildren()
       for (const child of children) {
-        renderer.root.remove(child.id)
+        renderer.root.remove(child)
       }
       renderer.root.add(ConfigView())
     }

--- a/src/router.ts
+++ b/src/router.ts
@@ -129,7 +129,7 @@ export function createRenderApp(renderer: CliRenderer): (forceRebuild?: boolean)
     for (const child of children) {
       if (child instanceof ToasterRenderable) continue
       if (child instanceof DialogContainerRenderable) continue
-      renderer.root.remove(child.id)
+      renderer.root.remove(child)
     }
 
     // Destroy chat list manager when leaving chats view

--- a/src/views/ConversationView.ts
+++ b/src/views/ConversationView.ts
@@ -328,7 +328,7 @@ export function ConversationView() {
   // Clear existing children and add messages
   const existingChildren = conversationScrollBox ? conversationScrollBox.getChildren() : []
   for (const child of existingChildren) {
-    conversationScrollBox!.remove(child.id)
+    conversationScrollBox!.remove(child)
   }
 
   // Add loading indicator at top (shown when loading older messages)


### PR DESCRIPTION
Fix  calls across the codebase that pass `child.id` (a string) instead of the child renderable object. The OpenTUI `remove()` method expects a renderable child object, not a string ID.

This caused an uncaught error when pressing `p` to switch from QR to phone pairing mode, and also produced spurious errors during QR code refresh.

### Files changed:
- `src/router.ts` — `renderer.root.remove(child)`
- `src/index.ts` — `renderer.root.remove(child)`
- `src/components/ChatPickerDialog.ts` — `listContainer.remove(child)`
- `src/components/EmojiPicker.ts` — `gridContainer/categoriesRow.remove(child)`
- `src/views/ConversationView.ts` — `conversationScrollBox.remove(child)`